### PR TITLE
Install black/ruff if not found in current python environment CF-495

### DIFF
--- a/codeflash/LICENSE
+++ b/codeflash/LICENSE
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             CodeFlash Inc.
-Licensed Work:        Codeflash Client version 0.9.x
+Licensed Work:        Codeflash Client version 0.0.x
                       The Licensed Work is (c) 2024 CodeFlash Inc.
 
 Additional Use Grant: None. Production use of the Licensed Work is only permitted
@@ -13,7 +13,7 @@ Additional Use Grant: None. Production use of the Licensed Work is only permitte
                       Platform. Please visit codeflash.ai for further
                       information.
 
-Change Date:          2029-01-06
+Change Date:          2029-02-17
 
 Change License:       MIT
 

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -578,8 +578,20 @@ def configure_pyproject_toml(setup_info: SetupInfo) -> None:
     formatter_cmds = []
     if formatter == "black":
         formatter_cmds.append("black $file")
+        print("checking if black exists")
+        try:
+            import black
+        except ImportError as e:
+            print("black not found, installing via pip")
+            subprocess.run(["pip", "install", "black"])
     elif formatter == "ruff":
         formatter_cmds.extend(["ruff check --exit-zero --fix $file", "ruff format $file"])
+        print("checking if ruff exists")
+        try:
+            import ruff
+        except ImportError as e:
+            print("ruff not found, installing via pip")
+            subprocess.run(["pip", "install", "ruff"])
     elif formatter == "other":
         formatter_cmds.append("your-formatter $file")
         click.echo(

--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced by poetry-dynamic-versioning during `poetry build`.
-__version__ = "0.9.2"
-__version_tuple__ = (0, 9, 2)
+__version__ = "0.0.0.post2491.dev0+2f81f2ca"
+__version_tuple__ = (0, 0, 0, "post2491", "dev0", "2f81f2ca")


### PR DESCRIPTION
Added a try/except block which tries to import the formatter, it calls `pip install` via `subprocess` if the import fails.