### PR TITLE
CF-495 Codeflash init - check if the formatter is installed

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -591,7 +591,7 @@ def configure_pyproject_toml(setup_info: SetupInfo) -> None:
         try:
             result = subprocess.run([formatter], capture_output=True, check=False)
         except FileNotFoundError as e:
-            click.echo(f"⚠️ Formatter not found: {formatter}, please install via \'pip install {formatter}\'")
+            click.echo(f"⚠️ Formatter not found: {formatter}, please ensure it is installed")
     codeflash_section["formatter-cmds"] = formatter_cmds
     # Add the 'codeflash' section, ensuring 'tool' section exists
     tool_section = pyproject_data.get("tool", tomlkit.table())

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -591,7 +591,7 @@ def configure_pyproject_toml(setup_info: SetupInfo) -> None:
         try:
             result = subprocess.run([formatter], capture_output=True, check=False)
         except FileNotFoundError as e:
-            click.echo(f"⚠️ Formatter not found: {formatter}")
+            click.echo(f"⚠️ Formatter not found: {formatter}, please install via \'pip install {formatter}\'")
     codeflash_section["formatter-cmds"] = formatter_cmds
     # Add the 'codeflash' section, ensuring 'tool' section exists
     tool_section = pyproject_data.get("tool", tomlkit.table())

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -590,13 +590,8 @@ def configure_pyproject_toml(setup_info: SetupInfo) -> None:
     if formatter in ["black", "ruff"]:
         try:
             result = subprocess.run([formatter], capture_output=True, check=False)
-            click.echo(f"✅ Formatter exists on system")
-            click.echo()
         except FileNotFoundError as e:
             click.echo(f"⚠️ Formatter not found: {formatter}")
-            click.echo()
-            # Not throwing an exception, letting the program proceed even though the formatter was not found, putting it on the user to install it later
-            # raise e from None
     codeflash_section["formatter-cmds"] = formatter_cmds
     # Add the 'codeflash' section, ensuring 'tool' section exists
     tool_section = pyproject_data.get("tool", tomlkit.table())

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -587,6 +587,16 @@ def configure_pyproject_toml(setup_info: SetupInfo) -> None:
         )
     elif formatter == "don't use a formatter":
         formatter_cmds.append("disabled")
+    if formatter in ["black", "ruff"]:
+        try:
+            result = subprocess.run([formatter], capture_output=True, check=False)
+            click.echo(f"✅ Formatter exists on system")
+            click.echo()
+        except FileNotFoundError as e:
+            click.echo(f"⚠️ Formatter not found: {formatter}")
+            click.echo()
+            # Not throwing an exception, letting the program proceed even though the formatter was not found, putting it on the user to install it later
+            # raise e from None
     codeflash_section["formatter-cmds"] = formatter_cmds
     # Add the 'codeflash' section, ensuring 'tool' section exists
     tool_section = pyproject_data.get("tool", tomlkit.table())


### PR DESCRIPTION
Not throwing an exception, letting the program proceed even though the formatter was not found, putting it on the user to install it later. Or we can ask to install it for them. 