### PR TITLE
fixed project config interfering with coverage config

### DIFF
--- a/codeflash/models/models.py
+++ b/codeflash/models/models.py
@@ -225,13 +225,13 @@ class CoverageData:
 
     @staticmethod
     def load_from_sqlite_database(
-        database_path: Path, function_name: str, code_context: CodeOptimizationContext, source_code_path: Path
+        database_path: Path, config_path: Path, function_name: str, code_context: CodeOptimizationContext, source_code_path: Path
     ) -> CoverageData:
         """Load coverage data from an SQLite database, mimicking the behavior of load_from_coverage_file."""
         from coverage import Coverage
         from coverage.jsonreport import JsonReporter
 
-        cov = Coverage(data_file=database_path, data_suffix=True, auto_data=True, branch=True)
+        cov = Coverage(data_file=database_path,config_file=config_path, data_suffix=True, auto_data=True, branch=True)
 
         if not database_path.stat().st_size or not database_path.exists():
             logger.debug(f"Coverage database {database_path} is empty or does not exist")

--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -1064,9 +1064,10 @@ class FunctionOptimizer:
         unittest_loop_index: int | None = None,
     ) -> tuple[TestResults, CoverageData | None]:
         coverage_database_file = None
+        coverage_config_file = None
         try:
             if testing_type == TestingMode.BEHAVIOR:
-                result_file_path, run_result, coverage_database_file = run_behavioral_tests(
+                result_file_path, run_result, coverage_database_file, coverage_config_file = run_behavioral_tests(
                     test_files,
                     test_framework=self.test_cfg.test_framework,
                     cwd=self.project_root,
@@ -1114,6 +1115,7 @@ class FunctionOptimizer:
             source_file=self.function_to_optimize.file_path,
             code_context=code_context,
             coverage_database_file=coverage_database_file,
+            coverage_config_file=coverage_config_file,
         )
         return results, coverage_results
 

--- a/codeflash/verification/parse_test_output.py
+++ b/codeflash/verification/parse_test_output.py
@@ -478,6 +478,7 @@ def parse_test_results(
     function_name: str | None,
     source_file: Path | None,
     coverage_database_file: Path | None,
+    coverage_config_file: Path | None,
     code_context: CodeOptimizationContext | None = None,
     run_result: subprocess.CompletedProcess | None = None,
     unittest_loop_index: int | None = None,
@@ -523,6 +524,7 @@ def parse_test_results(
         all_args = True
         coverage = CoverageData.load_from_sqlite_database(
             database_path=coverage_database_file,
+            config_path=coverage_config_file,
             source_code_path=source_file,
             code_context=code_context,
             function_name=function_name,

--- a/codeflash/verification/test_runner.py
+++ b/codeflash/verification/test_runner.py
@@ -36,7 +36,7 @@ def run_behavioral_tests(
     verbose: bool = False,
     pytest_target_runtime_seconds: int = TOTAL_LOOPING_TIME,
     enable_coverage: bool = False,
-) -> tuple[Path, subprocess.CompletedProcess, Path | None]:
+) -> tuple[Path, subprocess.CompletedProcess, Path | None, Path | None]:
     if test_framework == "pytest":
         test_files: list[str] = []
         for file in test_paths.test_files:
@@ -73,14 +73,14 @@ def run_behavioral_tests(
         pytest_test_env["PYTEST_PLUGINS"] = "codeflash.verification.pytest_plugin"
 
         if enable_coverage:
-            coverage_database_file, coveragercfile = prepare_coverage_files()
+            coverage_database_file, coverage_config_file = prepare_coverage_files()
 
             cov_erase = execute_test_subprocess(
                 shlex.split(f"{SAFE_SYS_EXECUTABLE} -m coverage erase"), cwd=cwd, env=pytest_test_env
             )  # this cleanup is necessary to avoid coverage data from previous runs, if there are any,
             # then the current run will be appended to the previous data, which skews the results
             logger.debug(cov_erase)
-            coverage_cmd = [SAFE_SYS_EXECUTABLE, "-m", "coverage", "run", f"--rcfile={coveragercfile.as_posix()}", "-m"]
+            coverage_cmd = [SAFE_SYS_EXECUTABLE, "-m", "coverage", "run", f"--rcfile={coverage_config_file.as_posix()}", "-m"]
 
             if pytest_cmd == "pytest":
                 coverage_cmd.extend(["pytest"])
@@ -120,7 +120,7 @@ def run_behavioral_tests(
         msg = f"Unsupported test framework: {test_framework}"
         raise ValueError(msg)
 
-    return result_file_path, results, coverage_database_file if enable_coverage else None
+    return result_file_path, results, coverage_database_file if enable_coverage else None, coverage_config_file if enable_coverage else None
 
 
 def run_benchmarking_tests(

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -40,7 +40,7 @@ class TestUnittestRunnerSorter(unittest.TestCase):
         )
         fp.write(code.encode("utf-8"))
         fp.flush()
-        result_file, process, coverage_pct = run_behavioral_tests(
+        result_file, process, _, _ = run_behavioral_tests(
             test_files,
             test_framework=config.test_framework,
             cwd=Path(config.project_root_path),
@@ -84,7 +84,7 @@ def test_sort():
         )
         fp.write(code.encode("utf-8"))
         fp.flush()
-        result_file, process, coverage_pct = run_behavioral_tests(
+        result_file, process, _, _ = run_behavioral_tests(
             test_files,
             test_framework=config.test_framework,
             cwd=Path(config.project_root_path),


### PR DESCRIPTION
When parsing results, we use the Coverage class. we need to pass in the config file that we generate. 