### PR TITLE
cf_install for all dep managers

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -362,7 +362,7 @@ def check_for_toml_or_setup_file() -> str | None:
     return cast(str, project_name)
 
 
-def install_github_actions(override_formatter_check: bool=False) -> None:
+def install_github_actions(override_formatter_check: bool = False) -> None:
     try:
         config, config_file_path = parse_config_file(override_formatter_check=override_formatter_check)
 
@@ -490,9 +490,12 @@ def get_dependency_installation_commands(dep_manager: DependencyManager) -> tupl
         return """|
           python -m pip install --upgrade pip
           pip install poetry
-          poetry install --all-extras"""
+          poetry install --all-extras
+          poetry add codeflash"""
     if dep_manager == DependencyManager.UV:
-        return "uv sync --all-extras"
+        return """|
+          uv sync --all-extras
+          uv pip install codeflash"""
     # PIP or UNKNOWN
     return """|
           python -m pip install --upgrade pip


### PR DESCRIPTION
### **User description**
![image](https://github.com/user-attachments/assets/f78ca793-46f2-4723-8a62-8cf2d9381291)


Next Error : - We should be trying to check if test directory is available or create one to avoid this error. 

INFO     Logging level set to INFO                                              
────────────────────────────────────────────────────────────────────────────────
Traceback (most recent call last):
  File "/home/runner/work/Python/Python/.venv/bin/codeflash", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runner/work/Python/Python/.venv/lib/python3.13/site-packages/codeflash/main.py", line 37, in main
    args = process_pyproject_config(args)
  File "/home/runner/work/Python/Python/.venv/lib/python3.13/site-packages/codeflash/cli_cmds/cli.py", line 12[9](https://github.com/Saga4/Python/actions/runs/14069164375/job/39399010566#step:6:10), in process_pyproject_config
    assert Path(args.tests_root).is_dir(), f"--tests-root {args.tests_root} must be a valid directory"
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
AssertionError: --tests-root /home/runner/work/Python/Python/tests must be a valid directory

___

### **PR Type**
- Enhancement



___

### **Description**
- Standardize formatting and spacing in function definitions.

- Enhance dependency installation commands for Poetry.

- Enhance dependency installation commands for uv.

- Add automatic installation of codeflash package.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cmd_init.py</strong><dd><code>Update dependency installation commands with codeflash add.</code></dd></summary>
<hr>

codeflash/cli_cmds/cmd_init.py

<li>Fixed spacing in install_github_actions parameter.<br> <li> Updated Poetry commands: added "poetry add codeflash".<br> <li> Updated uv commands: added "uv pip install codeflash".


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/71/files#diff-c15be1c100e57b623163c38b4995067f137d3ad0cf5c3e8cebeaa2f32ef86fc8">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>