### PR TITLE
Don't ask to reconfigure codeflash pyproject.toml if one already exists

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -67,20 +67,27 @@ def init_codeflash() -> None:
 
         did_add_new_key = prompt_api_key()
 
-        setup_info: SetupInfo = collect_setup_info()
+        if should_modify_pyproject_toml():
 
-        configure_pyproject_toml(setup_info)
+            setup_info: SetupInfo = collect_setup_info()
+
+            configure_pyproject_toml(setup_info)
 
         install_github_app()
 
         install_github_actions(override_formatter_check=True)
+
+        module_string = ""
+        if "setup_info" in locals():
+            module_string = f" you selected ({setup_info.module_root})"
+
 
         click.echo(
             f"{LF}"
             f"⚡️ Codeflash is now set up! You can now run:{LF}"
             f"    codeflash --file <path-to-file> --function <function-name> to optimize a function within a file{LF}"
             f"    codeflash --file <path-to-file> to optimize all functions in a file{LF}"
-            f"    codeflash --all to optimize all functions in all files in the module you selected ({setup_info.module_root}){LF}"
+            f"    codeflash --all to optimize all functions in all files in the module{module_string}{LF}"
             f"-or-{LF}"
             f"    codeflash --help to see all options{LF}"
         )
@@ -115,6 +122,30 @@ def ask_run_end_to_end_test(args: Namespace) -> None:
     if run_tests:
         bubble_sort_path, bubble_sort_test_path = create_bubble_sort_file_and_test(args)
         run_end_to_end_test(args, bubble_sort_path, bubble_sort_test_path)
+
+def should_modify_pyproject_toml() -> bool:
+    """
+    Check if the current directory contains a valid pyproject.toml file with codeflash config
+    If it does, ask the user if they want to re-configure it.
+    """
+    from rich.prompt import Confirm
+    pyproject_toml_path = Path.cwd() / "pyproject.toml"
+    if not pyproject_toml_path.exists():
+        return True
+    try:
+        config, config_file_path = parse_config_file(pyproject_toml_path)
+    except Exception as e:
+        return True
+
+    if "module_root" not in config or config["module_root"] is None or not Path(config["module_root"]).is_dir():
+        return True
+    if "tests_root" not in config or config["tests_root"] is None or not Path(config["tests_root"]).is_dir():
+        return True
+
+    create_toml = Confirm.ask(
+        f"✅ A valid Codeflash config already exists in this project. Do you want to re-configure it?", default=False, show_default=True
+    )
+    return create_toml
 
 
 def collect_setup_info() -> SetupInfo:

--- a/codeflash/code_utils/config_parser.py
+++ b/codeflash/code_utils/config_parser.py
@@ -85,7 +85,7 @@ def parse_config_file(config_file_path: Path | None = None, override_formatter_c
         "In pyproject.toml, Codeflash only supports the 'test-framework' as pytest and unittest."
     )
     if len(config["formatter-cmds"]) > 0:
-        #see if this is happening during Github actions setup
+        #see if this is happening during GitHub actions setup
         if not override_formatter_check:
             assert config["formatter-cmds"][0] != "your-formatter $file", (
                 "The formatter command is not set correctly in pyproject.toml. Please set the "


### PR DESCRIPTION
### **User description**
for the optimize-me repo, we were going to ask users to run codeflash init, but the repo already exists and users would waste time overwriting the config which could break it.


___

### **PR Type**
- Enhancement



___

### **Description**
- Add conditional check for pyproject.toml configuration.

- Introduce should_modify_pyproject_toml to prompt user confirmation.

- Update CLI messaging to conditionally display module information.

- Minor comment update for proper GitHub naming.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cmd_init.py</strong><dd><code>Conditional configuration and messaging update.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cmd_init.py

<li>Added check to avoid unnecessary config reconfiguration.<br> <li> Created should_modify_pyproject_toml function for user prompt.<br> <li> Updated echo message to show module info conditionally.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/100/files#diff-c15be1c100e57b623163c38b4995067f137d3ad0cf5c3e8cebeaa2f32ef86fc8">+34/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_parser.py</strong><dd><code>Comment clarification in configuration parser.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/config_parser.py

<li>Revised comment to correct GitHub naming convention.<br> <li> Minor adjustments to inline documentation.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/100/files#diff-0a10492dab4c0b830ed2a6f8fac08827d9976ff942013f6cbedb11d02e9df802">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>