### PR TITLE
Ran ruff on main branch

### DIFF
--- a/codeflash/cli_cmds/cli_common.py
+++ b/codeflash/cli_cmds/cli_common.py
@@ -74,7 +74,7 @@ def inquirer_wrapper_path(*args: str, **kwargs: str) -> dict[str, str] | None:
     new_kwargs["message"] = last_message
     new_args.append(args[0])
 
-    return cast(dict[str, str], inquirer.prompt([inquirer.Path(*new_args, **new_kwargs)]))
+    return cast("dict[str, str]", inquirer.prompt([inquirer.Path(*new_args, **new_kwargs)]))
 
 
 def split_string_to_fit_width(string: str, width: int) -> list[str]:

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -68,7 +68,6 @@ def init_codeflash() -> None:
         did_add_new_key = prompt_api_key()
 
         if should_modify_pyproject_toml():
-
             setup_info: SetupInfo = collect_setup_info()
 
             configure_pyproject_toml(setup_info)
@@ -80,7 +79,6 @@ def init_codeflash() -> None:
         module_string = ""
         if "setup_info" in locals():
             module_string = f" you selected ({setup_info.module_root})"
-
 
         click.echo(
             f"{LF}"
@@ -123,18 +121,19 @@ def ask_run_end_to_end_test(args: Namespace) -> None:
         bubble_sort_path, bubble_sort_test_path = create_bubble_sort_file_and_test(args)
         run_end_to_end_test(args, bubble_sort_path, bubble_sort_test_path)
 
+
 def should_modify_pyproject_toml() -> bool:
-    """
-    Check if the current directory contains a valid pyproject.toml file with codeflash config
+    """Check if the current directory contains a valid pyproject.toml file with codeflash config
     If it does, ask the user if they want to re-configure it.
     """
     from rich.prompt import Confirm
+
     pyproject_toml_path = Path.cwd() / "pyproject.toml"
     if not pyproject_toml_path.exists():
         return True
     try:
         config, config_file_path = parse_config_file(pyproject_toml_path)
-    except Exception as e:
+    except Exception:
         return True
 
     if "module_root" not in config or config["module_root"] is None or not Path(config["module_root"]).is_dir():
@@ -143,7 +142,9 @@ def should_modify_pyproject_toml() -> bool:
         return True
 
     create_toml = Confirm.ask(
-        f"✅ A valid Codeflash config already exists in this project. Do you want to re-configure it?", default=False, show_default=True
+        "✅ A valid Codeflash config already exists in this project. Do you want to re-configure it?",
+        default=False,
+        show_default=True,
     )
     return create_toml
 
@@ -224,7 +225,7 @@ def collect_setup_info() -> SetupInfo:
         else:
             apologize_and_exit()
     else:
-        tests_root = Path(curdir) / Path(cast(str, tests_root_answer))
+        tests_root = Path(curdir) / Path(cast("str", tests_root_answer))
     tests_root = tests_root.relative_to(curdir)
     ph("cli-tests-root-provided")
 
@@ -278,9 +279,9 @@ def collect_setup_info() -> SetupInfo:
     return SetupInfo(
         module_root=str(module_root),
         tests_root=str(tests_root),
-        test_framework=cast(str, test_framework),
+        test_framework=cast("str", test_framework),
         ignore_paths=ignore_paths,
-        formatter=cast(str, formatter),
+        formatter=cast("str", formatter),
         git_remote=str(git_remote),
     )
 
@@ -390,7 +391,7 @@ def check_for_toml_or_setup_file() -> str | None:
             click.echo("⏩️ Skipping pyproject.toml creation.")
             apologize_and_exit()
     click.echo()
-    return cast(str, project_name)
+    return cast("str", project_name)
 
 
 def install_github_actions(override_formatter_check: bool = False) -> None:

--- a/codeflash/code_utils/config_parser.py
+++ b/codeflash/code_utils/config_parser.py
@@ -87,7 +87,7 @@ def parse_config_file(
         "In pyproject.toml, Codeflash only supports the 'test-framework' as pytest and unittest."
     )
     if len(config["formatter-cmds"]) > 0:
-        #see if this is happening during GitHub actions setup
+        # see if this is happening during GitHub actions setup
         if not override_formatter_check:
             assert config["formatter-cmds"][0] != "your-formatter $file", (
                 "The formatter command is not set correctly in pyproject.toml. Please set the "

--- a/codeflash/discovery/functions_to_optimize.py
+++ b/codeflash/discovery/functions_to_optimize.py
@@ -300,7 +300,7 @@ def get_all_replay_test_functions(
                     if valid_function.qualified_name == function_name
                 ]
             )
-        if len(filtered_list):
+        if filtered_list:
             filtered_valid_functions[file_path] = filtered_list
 
     return filtered_valid_functions

--- a/codeflash/models/models.py
+++ b/codeflash/models/models.py
@@ -527,7 +527,7 @@ class TestResults(BaseModel):
         if len(self) != len(other):
             return False
         original_recursion_limit = sys.getrecursionlimit()
-        cast(TestResults, other)
+        cast("TestResults", other)
         for test_result in self:
             other_test_result = other.get_by_unique_invocation_loop_id(test_result.unique_invocation_loop_id)
             if other_test_result is None:


### PR DESCRIPTION
### **User description**
ran ruff check --fix . ; ruff format .


___

### **PR Type**
- Enhancement



___

### **Description**
- Replace type cast to use string literal annotations.

- Reformat inline comments and docstrings.

- Simplify condition check for list content.

- Tidy exception handling in configuration parser.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli_common.py</strong><dd><code>Update cast usage with string literal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cli_common.py

<li>Updated cast call to use string literal type.<br> <li> Minor formatting adjustments.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/102/files#diff-0bdc0fee6583bd7a585f3d8b186ab6fc8ac3d9d497232b20a8306c4a39dc3645">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cmd_init.py</strong><dd><code>Refactor CLI init functions and cast usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cmd_init.py

<li>Updated exception handling in pyproject_toml function.<br> <li> Replaced cast calls using string literal types.<br> <li> Reformatted Confirm.ask arguments.<br> <li> Improved code formatting in CLI initialization.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/102/files#diff-c15be1c100e57b623163c38b4995067f137d3ad0cf5c3e8cebeaa2f32ef86fc8">+11/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>functions_to_optimize.py</strong><dd><code>Simplify function existence check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/discovery/functions_to_optimize.py

<li>Simplified check from len(filtered_list) to condition.<br> <li> Improves code clarity.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/102/files#diff-adb17c14509d2bdc69ea39d82dfdde9c4c1c30277f9c8765b74ebb016b0c3cb3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Update cast in model equality check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/models/models.py

<li>Changed cast call in __eq__ to use string literal.<br> <li> Enhances type checking clarity.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/102/files#diff-d0d6694a64006de8fc957fd466d53cc5ba3e41d81eca202c2ee1c574cf987766">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_parser.py</strong><dd><code>Fix comment formatting in config parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/config_parser.py

<li>Adjusted in-line comment formatting.<br> <li> Minor style update in config parsing.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/102/files#diff-0a10492dab4c0b830ed2a6f8fac08827d9976ff942013f6cbedb11d02e9df802">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>