### PR TITLE
Add GitHub issues link to error messages

### DIFF
--- a/codeflash/main.py
+++ b/codeflash/main.py
@@ -2,19 +2,20 @@
 solved problem, please reach out to us at careers@codeflash.ai. We're hiring!
 """
 
+import sys
 from pathlib import Path
 
 from codeflash.cli_cmds.cli import parse_args, process_pyproject_config
 from codeflash.cli_cmds.cmd_init import CODEFLASH_LOGO, ask_run_end_to_end_test
-from codeflash.cli_cmds.console import paneled_text
+from codeflash.cli_cmds.console import logger, paneled_text
 from codeflash.code_utils.config_parser import parse_config_file
 from codeflash.optimization import optimizer
 from codeflash.telemetry import posthog_cf
 from codeflash.telemetry.sentry import init_sentry
 
 
-def main() -> None:
-    """Entry point for the codeflash command-line interface."""
+def _main() -> None:
+    """Internal entry point for the codeflash command-line interface."""
     paneled_text(
         CODEFLASH_LOGO, panel_args={"title": "https://codeflash.ai", "expand": False}, text_args={"style": "bold gold3"}
     )
@@ -38,6 +39,16 @@ def main() -> None:
         init_sentry(not args.disable_telemetry, exclude_errors=True)
         posthog_cf.initialize_posthog(not args.disable_telemetry)
         optimizer.run_with_args(args)
+
+
+def main() -> None:
+    """Entry point for the codeflash command-line interface with global exception handling."""
+    try:
+        _main()
+    except Exception as e:
+        logger.error(f"Error: {str(e)}")
+        logger.error("Raise an issue on Codeflash's Github issues at - https://github.com/codeflash-ai/codeflash/issues")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### **User description**
When Codeflash raises an exception that crashes the program, the error message now includes a link to the GitHub issues page.

This PR adds a global exception handler in the main entry point that catches all unhandled exceptions and adds the message: "Raise an issue on Codeflash's Github issues at - https://github.com/codeflash-ai/codeflash/issues"


___

### **PR Type**
- Enhancement



___

### **Description**
- Introduce global exception handling in main.

- Log error with a GitHub issues link.

- Rename internal main function to _main.

- Import sys for error handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add global error handling and function refactor.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/main.py

<li>Added global try-except in main.<br> <li> Renamed original main to _main.<br> <li> Logged error with GitHub issues link.<br> <li> Imported sys for exception handling.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/113/files#diff-614158f7df64c99b273134232885e41602312147cb983bd903d63a69f6f813e7">+14/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>