### PR TITLE
loosen pytest requirements

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -32,7 +32,7 @@ jobs:
         run: uvx poetry install --with dev
 
       - name: Unit tests
-        run: uvx poetry run pytest tests/ --cov --cov-report=xml
+        run: uvx poetry run pytest tests/ --cov --cov-report=xml --disable-warnings
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9.18, 3.10.13, 3.11.6, 3.12.1, 3.13.0]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,7 @@ celerybeat.pid
 # Environments
 .env
 **/.env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/codeflash/code_utils/instrument_existing_tests.py
+++ b/codeflash/code_utils/instrument_existing_tests.py
@@ -4,10 +4,9 @@ import ast
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import isort
-
 from codeflash.cli_cmds.console import logger
 from codeflash.code_utils.code_utils import get_run_tmp_file, module_name_from_file_path
+from codeflash.code_utils.formatter import format_code_in_memory
 from codeflash.discovery.functions_to_optimize import FunctionToOptimize
 from codeflash.models.models import FunctionParent, TestingMode, VerificationType
 
@@ -355,8 +354,7 @@ def inject_profiling_into_existing_test(
     if test_framework == "unittest":
         new_imports.append(ast.Import(names=[ast.alias(name="timeout_decorator")]))
     tree.body = [*new_imports, create_wrapper_function(mode), *tree.body]
-    return True, isort.code(ast.unparse(tree), float_to_top=True)
-
+    return True, format_code_in_memory(ast.unparse(tree))
 
 def create_wrapper_function(mode: TestingMode = TestingMode.BEHAVIOR) -> ast.FunctionDef:
     lineno = 1

--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -35,7 +35,7 @@ from codeflash.code_utils.config_consts import (
     N_TESTS_TO_GENERATE,
     TOTAL_LOOPING_TIME,
 )
-from codeflash.code_utils.formatter import format_code, sort_imports
+from codeflash.code_utils.formatter import format_code, format_code_in_memory
 from codeflash.code_utils.instrument_existing_tests import inject_profiling_into_existing_test
 from codeflash.code_utils.line_profile_utils import add_decorator_imports
 from codeflash.code_utils.remove_generated_tests import remove_functions_from_generated_tests
@@ -541,14 +541,14 @@ class FunctionOptimizer:
 
         new_code = format_code(self.args.formatter_cmds, path)
         if should_sort_imports:
-            new_code = sort_imports(new_code)
+            new_code = format_code_in_memory(new_code, imports_only=True)
 
         new_helper_code: dict[Path, str] = {}
         helper_functions_paths = {hf.file_path for hf in helper_functions}
         for module_abspath in helper_functions_paths:
             formatted_helper_code = format_code(self.args.formatter_cmds, module_abspath)
             if should_sort_imports:
-                formatted_helper_code = sort_imports(formatted_helper_code)
+                formatted_helper_code = format_code_in_memory(formatted_helper_code, imports_only=True)
             new_helper_code[module_abspath] = formatted_helper_code
 
         return new_code, new_helper_code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = ">=3.9"
 unidiff = ">=0.7.4"
-pytest = ">=7.0.0,<8.3.4"
+pytest = ">=7.0.0"
 gitpython = ">=3.1.31"
 libcst = ">=1.0.1"
 jedi = ">=0.19.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ lxml = ">=5.3.0"
 crosshair-tool = ">=0.0.78"
 coverage = ">=7.6.4"
 line_profiler=">=4.2.0" #this is the minimum version which supports python 3.13
+black = "^25.1.0"
 [tool.poetry.group.dev]
 optional = true
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -5,13 +5,13 @@ from pathlib import Path
 import pytest
 
 from codeflash.code_utils.config_parser import parse_config_file
-from codeflash.code_utils.formatter import format_code, sort_imports
+from codeflash.code_utils.formatter import format_code, format_code_in_memory
 
 
 def test_remove_duplicate_imports():
     """Test that duplicate imports are removed when should_sort_imports is True."""
     original_code = "import os\nimport os\n"
-    new_code = sort_imports(original_code)
+    new_code = format_code_in_memory(original_code, imports_only=True)
     assert new_code == "import os\n"
 
 
@@ -19,7 +19,7 @@ def test_remove_multiple_duplicate_imports():
     """Test that multiple duplicate imports are removed when should_sort_imports is True."""
     original_code = "import sys\nimport os\nimport sys\n"
 
-    new_code = sort_imports(original_code)
+    new_code = format_code_in_memory(original_code, imports_only=True)
     assert new_code == "import os\nimport sys\n"
 
 
@@ -27,7 +27,7 @@ def test_sorting_imports():
     """Test that imports are sorted when should_sort_imports is True."""
     original_code = "import sys\nimport unittest\nimport os\n"
 
-    new_code = sort_imports(original_code)
+    new_code = format_code_in_memory(original_code, imports_only=True)
     assert new_code == "import os\nimport sys\nimport unittest\n"
 
 
@@ -40,7 +40,7 @@ def test_sort_imports_without_formatting():
 
         new_code = format_code(formatter_cmds=["disabled"], path=tmp_path)
         assert new_code is not None
-        new_code = sort_imports(new_code)
+        new_code = format_code_in_memory(new_code, imports_only=True)
         assert new_code == "import os\nimport sys\nimport unittest\n"
 
 
@@ -63,7 +63,7 @@ def foo():
     return os.path.join(sys.path[0], 'bar')
 """
 
-    actual = sort_imports(original_code)
+    actual = format_code_in_memory(original_code, imports_only=True)
 
     assert actual == expected
 
@@ -90,7 +90,7 @@ def foo():
     return os.path.join(sys.path[0], 'bar')
 """
 
-    actual = sort_imports(original_code)
+    actual = format_code_in_memory(original_code, imports_only=True)
 
     assert actual == expected
 

--- a/tests/test_instrument_all_and_run.py
+++ b/tests/test_instrument_all_and_run.py
@@ -12,6 +12,7 @@ from codeflash.discovery.functions_to_optimize import FunctionToOptimize
 from codeflash.models.models import CodePosition, FunctionParent, TestFile, TestFiles, TestingMode, TestType
 from codeflash.optimization.optimizer import Optimizer
 from codeflash.verification.equivalence import compare_test_results
+from codeflash.code_utils.formatter import format_code_in_memory
 from codeflash.verification.instrument_codeflash_capture import instrument_codeflash_capture
 
 # Used by cli instrumentation
@@ -119,10 +120,12 @@ def test_sort():
         os.chdir(original_cwd)
         assert success
         assert new_test is not None
-        assert new_test.replace('"', "'") == expected.format(
+        assert format_code_in_memory(new_test) == format_code_in_memory(
+            expected.format(
             module_path="code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp",
             tmp_dir_path=get_run_tmp_file(Path("test_return_values")),
-        ).replace('"', "'")
+            )
+        )
 
         with test_path.open("w") as f:
             f.write(new_test)
@@ -307,9 +310,9 @@ def test_sort():
             Path(f.name), [CodePosition(7, 13), CodePosition(12, 13)], fto, Path(f.name).parent, "pytest"
         )
     assert success
-    assert new_test.replace('"', "'") == expected.format(
+    assert format_code_in_memory(new_test) == format_code_in_memory(expected.format(
         module_path=Path(f.name).name, tmp_dir_path=get_run_tmp_file(Path("test_return_values"))
-    ).replace('"', "'")
+    ))
     tests_root = (Path(__file__).parent.resolve() / "../code_to_optimize/tests/pytest/").resolve()
     test_path = tests_root / "test_class_method_behavior_results_temp.py"
     test_path_perf = tests_root / "test_class_method_behavior_results_perf_temp.py"

--- a/tests/test_instrument_tests.py
+++ b/tests/test_instrument_tests.py
@@ -139,7 +139,9 @@ def codeflash_wrap(
     invocation_id = f"{{line_id}}_{{codeflash_test_index}}"
 '''
     if sys.version_info < (3, 12):
-        expected += """print(f"!######{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}######!")"""
+        expected += """    print(
+        f"!######{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}######!"
+    )"""
     else:
         expected += """    print(
         f"!######{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}######!"
@@ -312,7 +314,9 @@ def codeflash_wrap(
     invocation_id = f"{{line_id}}_{{codeflash_test_index}}"
 '''
     if sys.version_info < (3, 12):
-        expected += """print(f"!######{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}######!")"""
+        expected += """    print(
+        fr"!######{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}######!"
+    )"""
     else:
         expected += """    print(
         f"!######{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}######!"
@@ -504,7 +508,6 @@ def test_sort():
             module_path="code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp",
             tmp_dir_path=get_run_tmp_file(Path("test_return_values")),
         ))
-
         with test_path.open("w") as f:
             f.write(new_test)
 
@@ -542,91 +545,91 @@ def test_sort():
             testing_time=0.1,
         )
         assert test_results[0].id.function_getting_tested == "sorter"
-        assert test_results[0].id.iteration_id == "1_0"
-        assert test_results[0].id.test_class_name is None
-        assert test_results[0].id.test_function_name == "test_sort"
-        assert (
-            test_results[0].id.test_module_path
-            == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
-        )
-        assert test_results[0].runtime > 0
-        assert test_results[0].did_pass
-        assert test_results[0].return_value == ([0, 1, 2, 3, 4, 5],)
+        # assert test_results[0].id.iteration_id == "1_0"
+        # assert test_results[0].id.test_class_name is None
+        # assert test_results[0].id.test_function_name == "test_sort"
+        # assert (
+        #     test_results[0].id.test_module_path
+        #     == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
+        # )
+#         assert test_results[0].runtime > 0
+#         assert test_results[0].did_pass
+#         assert test_results[0].return_value == ([0, 1, 2, 3, 4, 5],)
 
-        assert test_results[1].id.function_getting_tested == "sorter"
-        assert test_results[1].id.iteration_id == "4_0"
-        assert test_results[1].id.test_class_name is None
-        assert test_results[1].id.test_function_name == "test_sort"
-        assert (
-            test_results[1].id.test_module_path
-            == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
-        )
-        assert test_results[1].runtime > 0
-        assert test_results[1].did_pass
+#         assert test_results[1].id.function_getting_tested == "sorter"
+#         assert test_results[1].id.iteration_id == "4_0"
+#         assert test_results[1].id.test_class_name is None
+#         assert test_results[1].id.test_function_name == "test_sort"
+#         assert (
+#             test_results[1].id.test_module_path
+#             == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
+#         )
+#         assert test_results[1].runtime > 0
+#         assert test_results[1].did_pass
 
-        with test_path_perf.open("w") as f:
-            f.write(new_perf_test)
+#         with test_path_perf.open("w") as f:
+#             f.write(new_perf_test)
 
-        test_results_perf, _ = func_optimizer.run_and_parse_tests(
-            testing_type=TestingMode.PERFORMANCE,
-            test_env=test_env,
-            test_files=test_files,
-            optimization_iteration=0,
-            pytest_min_loops=1,
-            pytest_max_loops=1,
-            testing_time=0.1,
-        )
-        assert test_results_perf[0].id.function_getting_tested == "sorter"
-        assert test_results_perf[0].id.iteration_id == "1_0"
-        assert test_results_perf[0].id.test_class_name is None
-        assert test_results_perf[0].id.test_function_name == "test_sort"
-        assert (
-            test_results_perf[0].id.test_module_path
-            == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
-        )
-        assert test_results_perf[0].runtime > 0
-        assert test_results_perf[0].did_pass
-        assert test_results_perf[0].return_value is None
+#         test_results_perf, _ = func_optimizer.run_and_parse_tests(
+#             testing_type=TestingMode.PERFORMANCE,
+#             test_env=test_env,
+#             test_files=test_files,
+#             optimization_iteration=0,
+#             pytest_min_loops=1,
+#             pytest_max_loops=1,
+#             testing_time=0.1,
+#         )
+#         assert test_results_perf[0].id.function_getting_tested == "sorter"
+#         assert test_results_perf[0].id.iteration_id == "1_0"
+#         assert test_results_perf[0].id.test_class_name is None
+#         assert test_results_perf[0].id.test_function_name == "test_sort"
+#         assert (
+#             test_results_perf[0].id.test_module_path
+#             == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
+#         )
+#         assert test_results_perf[0].runtime > 0
+#         assert test_results_perf[0].did_pass
+#         assert test_results_perf[0].return_value is None
 
-        assert test_results_perf[1].id.function_getting_tested == "sorter"
-        assert test_results_perf[1].id.iteration_id == "4_0"
-        assert test_results_perf[1].id.test_class_name is None
-        assert test_results_perf[1].id.test_function_name == "test_sort"
-        assert (
-            test_results_perf[1].id.test_module_path
-            == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
-        )
-        assert test_results_perf[1].runtime > 0
-        assert test_results_perf[1].did_pass
-        out_str = """codeflash stdout: Sorting list
-result: [0, 1, 2, 3, 4, 5]
+#         assert test_results_perf[1].id.function_getting_tested == "sorter"
+#         assert test_results_perf[1].id.iteration_id == "4_0"
+#         assert test_results_perf[1].id.test_class_name is None
+#         assert test_results_perf[1].id.test_function_name == "test_sort"
+#         assert (
+#             test_results_perf[1].id.test_module_path
+#             == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
+#         )
+#         assert test_results_perf[1].runtime > 0
+#         assert test_results_perf[1].did_pass
+#         out_str = """codeflash stdout: Sorting list
+# result: [0, 1, 2, 3, 4, 5]
 
-codeflash stdout: Sorting list
-result: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]"""
-        assert out_str == test_results_perf[1].stdout
-        ctx_result = func_optimizer.get_code_optimization_context()
-        code_context: CodeOptimizationContext = ctx_result.unwrap()
-        original_helper_code: dict[Path, str] = {}
-        helper_function_paths = {hf.file_path for hf in code_context.helper_functions}
-        for helper_function_path in helper_function_paths:
-            with helper_function_path.open(encoding="utf8") as f:
-                helper_code = f.read()
-                original_helper_code[helper_function_path] = helper_code
-        computed_fn_opt = True
-        line_profiler_output_file = add_decorator_imports(
-            func_optimizer.function_to_optimize, code_context)
-        line_profile_results, _ = func_optimizer.run_and_parse_tests(
-            testing_type=TestingMode.LINE_PROFILE,
-            test_env=test_env,
-            test_files=test_files,
-            optimization_iteration=0,
-            pytest_min_loops=1,
-            pytest_max_loops=1,
-            testing_time=0.1,
-            line_profiler_output_file = line_profiler_output_file
-        )
-        tmp_lpr = list(line_profile_results["timings"].keys())
-        assert len(tmp_lpr) == 1 and line_profile_results["timings"][tmp_lpr[0]][0][1]==2
+# codeflash stdout: Sorting list
+# result: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]"""
+#         assert out_str == test_results_perf[1].stdout
+#         ctx_result = func_optimizer.get_code_optimization_context()
+#         code_context: CodeOptimizationContext = ctx_result.unwrap()
+#         original_helper_code: dict[Path, str] = {}
+#         helper_function_paths = {hf.file_path for hf in code_context.helper_functions}
+#         for helper_function_path in helper_function_paths:
+#             with helper_function_path.open(encoding="utf8") as f:
+#                 helper_code = f.read()
+#                 original_helper_code[helper_function_path] = helper_code
+#         computed_fn_opt = True
+#         line_profiler_output_file = add_decorator_imports(
+#             func_optimizer.function_to_optimize, code_context)
+#         line_profile_results, _ = func_optimizer.run_and_parse_tests(
+#             testing_type=TestingMode.LINE_PROFILE,
+#             test_env=test_env,
+#             test_files=test_files,
+#             optimization_iteration=0,
+#             pytest_min_loops=1,
+#             pytest_max_loops=1,
+#             testing_time=0.1,
+#             line_profiler_output_file = line_profiler_output_file
+#         )
+#         tmp_lpr = list(line_profile_results["timings"].keys())
+#         assert len(tmp_lpr) == 1 and line_profile_results["timings"][tmp_lpr[0]][0][1]==2
     finally:
         if computed_fn_opt:
             func_optimizer.write_code_and_helpers(

--- a/tests/test_instrument_tests.py
+++ b/tests/test_instrument_tests.py
@@ -315,7 +315,7 @@ def codeflash_wrap(
 '''
     if sys.version_info < (3, 12):
         expected += """    print(
-        fr"!######{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}######!"
+        f"!######{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}######!"
     )"""
     else:
         expected += """    print(
@@ -545,91 +545,91 @@ def test_sort():
             testing_time=0.1,
         )
         assert test_results[0].id.function_getting_tested == "sorter"
-        # assert test_results[0].id.iteration_id == "1_0"
-        # assert test_results[0].id.test_class_name is None
-        # assert test_results[0].id.test_function_name == "test_sort"
-        # assert (
-        #     test_results[0].id.test_module_path
-        #     == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
-        # )
-#         assert test_results[0].runtime > 0
-#         assert test_results[0].did_pass
-#         assert test_results[0].return_value == ([0, 1, 2, 3, 4, 5],)
+        assert test_results[0].id.iteration_id == "1_0"
+        assert test_results[0].id.test_class_name is None
+        assert test_results[0].id.test_function_name == "test_sort"
+        assert (
+            test_results[0].id.test_module_path
+            == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
+        )
+        assert test_results[0].runtime > 0
+        assert test_results[0].did_pass
+        assert test_results[0].return_value == ([0, 1, 2, 3, 4, 5],)
 
-#         assert test_results[1].id.function_getting_tested == "sorter"
-#         assert test_results[1].id.iteration_id == "4_0"
-#         assert test_results[1].id.test_class_name is None
-#         assert test_results[1].id.test_function_name == "test_sort"
-#         assert (
-#             test_results[1].id.test_module_path
-#             == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
-#         )
-#         assert test_results[1].runtime > 0
-#         assert test_results[1].did_pass
+        assert test_results[1].id.function_getting_tested == "sorter"
+        assert test_results[1].id.iteration_id == "4_0"
+        assert test_results[1].id.test_class_name is None
+        assert test_results[1].id.test_function_name == "test_sort"
+        assert (
+            test_results[1].id.test_module_path
+            == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
+        )
+        assert test_results[1].runtime > 0
+        assert test_results[1].did_pass
 
-#         with test_path_perf.open("w") as f:
-#             f.write(new_perf_test)
+        with test_path_perf.open("w") as f:
+            f.write(new_perf_test)
 
-#         test_results_perf, _ = func_optimizer.run_and_parse_tests(
-#             testing_type=TestingMode.PERFORMANCE,
-#             test_env=test_env,
-#             test_files=test_files,
-#             optimization_iteration=0,
-#             pytest_min_loops=1,
-#             pytest_max_loops=1,
-#             testing_time=0.1,
-#         )
-#         assert test_results_perf[0].id.function_getting_tested == "sorter"
-#         assert test_results_perf[0].id.iteration_id == "1_0"
-#         assert test_results_perf[0].id.test_class_name is None
-#         assert test_results_perf[0].id.test_function_name == "test_sort"
-#         assert (
-#             test_results_perf[0].id.test_module_path
-#             == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
-#         )
-#         assert test_results_perf[0].runtime > 0
-#         assert test_results_perf[0].did_pass
-#         assert test_results_perf[0].return_value is None
+        test_results_perf, _ = func_optimizer.run_and_parse_tests(
+            testing_type=TestingMode.PERFORMANCE,
+            test_env=test_env,
+            test_files=test_files,
+            optimization_iteration=0,
+            pytest_min_loops=1,
+            pytest_max_loops=1,
+            testing_time=0.1,
+        )
+        assert test_results_perf[0].id.function_getting_tested == "sorter"
+        assert test_results_perf[0].id.iteration_id == "1_0"
+        assert test_results_perf[0].id.test_class_name is None
+        assert test_results_perf[0].id.test_function_name == "test_sort"
+        assert (
+            test_results_perf[0].id.test_module_path
+            == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
+        )
+        assert test_results_perf[0].runtime > 0
+        assert test_results_perf[0].did_pass
+        assert test_results_perf[0].return_value is None
 
-#         assert test_results_perf[1].id.function_getting_tested == "sorter"
-#         assert test_results_perf[1].id.iteration_id == "4_0"
-#         assert test_results_perf[1].id.test_class_name is None
-#         assert test_results_perf[1].id.test_function_name == "test_sort"
-#         assert (
-#             test_results_perf[1].id.test_module_path
-#             == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
-#         )
-#         assert test_results_perf[1].runtime > 0
-#         assert test_results_perf[1].did_pass
-#         out_str = """codeflash stdout: Sorting list
-# result: [0, 1, 2, 3, 4, 5]
+        assert test_results_perf[1].id.function_getting_tested == "sorter"
+        assert test_results_perf[1].id.iteration_id == "4_0"
+        assert test_results_perf[1].id.test_class_name is None
+        assert test_results_perf[1].id.test_function_name == "test_sort"
+        assert (
+            test_results_perf[1].id.test_module_path
+            == "code_to_optimize.tests.pytest.test_perfinjector_bubble_sort_results_temp"
+        )
+        assert test_results_perf[1].runtime > 0
+        assert test_results_perf[1].did_pass
+        out_str = """codeflash stdout: Sorting list
+result: [0, 1, 2, 3, 4, 5]
 
-# codeflash stdout: Sorting list
-# result: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]"""
-#         assert out_str == test_results_perf[1].stdout
-#         ctx_result = func_optimizer.get_code_optimization_context()
-#         code_context: CodeOptimizationContext = ctx_result.unwrap()
-#         original_helper_code: dict[Path, str] = {}
-#         helper_function_paths = {hf.file_path for hf in code_context.helper_functions}
-#         for helper_function_path in helper_function_paths:
-#             with helper_function_path.open(encoding="utf8") as f:
-#                 helper_code = f.read()
-#                 original_helper_code[helper_function_path] = helper_code
-#         computed_fn_opt = True
-#         line_profiler_output_file = add_decorator_imports(
-#             func_optimizer.function_to_optimize, code_context)
-#         line_profile_results, _ = func_optimizer.run_and_parse_tests(
-#             testing_type=TestingMode.LINE_PROFILE,
-#             test_env=test_env,
-#             test_files=test_files,
-#             optimization_iteration=0,
-#             pytest_min_loops=1,
-#             pytest_max_loops=1,
-#             testing_time=0.1,
-#             line_profiler_output_file = line_profiler_output_file
-#         )
-#         tmp_lpr = list(line_profile_results["timings"].keys())
-#         assert len(tmp_lpr) == 1 and line_profile_results["timings"][tmp_lpr[0]][0][1]==2
+codeflash stdout: Sorting list
+result: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]"""
+        assert out_str == test_results_perf[1].stdout
+        ctx_result = func_optimizer.get_code_optimization_context()
+        code_context: CodeOptimizationContext = ctx_result.unwrap()
+        original_helper_code: dict[Path, str] = {}
+        helper_function_paths = {hf.file_path for hf in code_context.helper_functions}
+        for helper_function_path in helper_function_paths:
+            with helper_function_path.open(encoding="utf8") as f:
+                helper_code = f.read()
+                original_helper_code[helper_function_path] = helper_code
+        computed_fn_opt = True
+        line_profiler_output_file = add_decorator_imports(
+            func_optimizer.function_to_optimize, code_context)
+        line_profile_results, _ = func_optimizer.run_and_parse_tests(
+            testing_type=TestingMode.LINE_PROFILE,
+            test_env=test_env,
+            test_files=test_files,
+            optimization_iteration=0,
+            pytest_min_loops=1,
+            pytest_max_loops=1,
+            testing_time=0.1,
+            line_profiler_output_file = line_profiler_output_file
+        )
+        tmp_lpr = list(line_profile_results["timings"].keys())
+        assert len(tmp_lpr) == 1 and line_profile_results["timings"][tmp_lpr[0]][0][1]==2
     finally:
         if computed_fn_opt:
             func_optimizer.write_code_and_helpers(


### PR DESCRIPTION
### **PR Type**
- Enhancement
- Tests



___

### **Description**
- Add new function `format_code_in_memory` with Black support.

- Replace `sort_imports` calls with `format_code_in_memory`.

- Update tests to use new formatting and sorting method.

- Loosen pytest version constraints and add Black dependency in CI.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>formatter.py</strong><dd><code>Introduce `format_code_in_memory` with Black integration</code>&nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/135/files#diff-ead54b6ab4522d27ae1bc0af93885ab05a8f49ea3c96308972c17deaa97515d2">+18/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>instrument_existing_tests.py</strong><dd><code>Replace isort call with `format_code_in_memory` in instrumentation</code></dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/135/files#diff-9b25e719711dbe9ac8f34ee1b937cbd0bb75a48b7a3526b9855433a620edb29a">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>function_optimizer.py</strong><dd><code>Update import sorting to use new formatting function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/135/files#diff-c31e19bcea34bd30ef3c0be56164bea577174363ba3320c4999bf1926ea8ce79">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_formatter.py</strong><dd><code>Replace `sort_imports` with `format_code_in_memory` in tests</code></dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/135/files#diff-e0cd3f215f68d0608393c012e268cb2f896c1e88315c97fa77e114d400f5283b">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_instrument_all_and_run.py</strong><dd><code>Update test assertions to use new formatting function</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/135/files#diff-f4a2a3bb7c73d1c110a98cfbc98fe85e028ee8932b06c41cc2175353ec1e326d">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_instrument_tests.py</strong><dd><code>Multiple test updates for formatting consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/135/files#diff-7edc17a8f718b9ee52dc20091cb34041920cfc0d513cb8dcd25b6e9ce03a3dec">+198/-89</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>unit-tests.yaml</strong><dd><code>Add --disable-warnings option to pytest command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/135/files#diff-6e608e02c595d53ab6b70822a2bf19abcfc6ddcc976c2f536ad5bfca20f0443f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Loosen pytest constraint and add Black dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/135/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>