### PR TITLE
trailing slahes were not handled properly when parsing the owner and repo

### DIFF
--- a/codeflash/code_utils/git_utils.py
+++ b/codeflash/code_utils/git_utils.py
@@ -82,6 +82,7 @@ def get_git_remotes(repo: Repo) -> list[str]:
 def get_repo_owner_and_name(repo: Repo | None = None, git_remote: str | None = "origin") -> tuple[str, str]:
     remote_url = get_remote_url(repo, git_remote)  # call only once
     remote_url = remote_url.removesuffix(".git") if remote_url.endswith(".git") else remote_url
+    # remote_url = get_remote_url(repo, git_remote).removesuffix(".git") if remote_url.endswith(".git") else remote_url
     remote_url = remote_url.rstrip("/")
     split_url = remote_url.split("/")
     repo_owner_with_github, repo_name = split_url[-2], split_url[-1]

--- a/codeflash/code_utils/git_utils.py
+++ b/codeflash/code_utils/git_utils.py
@@ -82,11 +82,9 @@ def get_git_remotes(repo: Repo) -> list[str]:
 def get_repo_owner_and_name(repo: Repo | None = None, git_remote: str | None = "origin") -> tuple[str, str]:
     remote_url = get_remote_url(repo, git_remote)  # call only once
     remote_url = remote_url.removesuffix(".git") if remote_url.endswith(".git") else remote_url
+    remote_url = remote_url.rstrip("/")
     split_url = remote_url.split("/")
-    if split_url[-1] == "":
-        repo_owner_with_github, repo_name = split_url[-3], split_url[-2]
-    else:
-        repo_owner_with_github, repo_name = split_url[-2], split_url[-1]
+    repo_owner_with_github, repo_name = split_url[-2], split_url[-1]
     repo_owner = repo_owner_with_github.split(":")[1] if ":" in repo_owner_with_github else repo_owner_with_github
     return repo_owner, repo_name
 

--- a/codeflash/code_utils/git_utils.py
+++ b/codeflash/code_utils/git_utils.py
@@ -82,9 +82,11 @@ def get_git_remotes(repo: Repo) -> list[str]:
 def get_repo_owner_and_name(repo: Repo | None = None, git_remote: str | None = "origin") -> tuple[str, str]:
     remote_url = get_remote_url(repo, git_remote)  # call only once
     remote_url = remote_url.removesuffix(".git") if remote_url.endswith(".git") else remote_url
-    # remote_url = get_remote_url(repo, git_remote).removesuffix(".git") if remote_url.endswith(".git") else remote_url
     split_url = remote_url.split("/")
-    repo_owner_with_github, repo_name = split_url[-2], split_url[-1]
+    if split_url[-1] == "":
+        repo_owner_with_github, repo_name = split_url[-3], split_url[-2]
+    else:
+        repo_owner_with_github, repo_name = split_url[-2], split_url[-1]
     repo_owner = repo_owner_with_github.split(":")[1] if ":" in repo_owner_with_github else repo_owner_with_github
     return repo_owner, repo_name
 

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -33,6 +33,12 @@ class TestGitUtils(unittest.TestCase):
         assert owner == "owner"
         assert repo_name == "repo"
 
+        # Test with another GitHub SSH URL
+        mock_get_remote_url.return_value = "git@github.com:codeflash-ai/posthog/"
+        owner, repo_name = get_repo_owner_and_name()
+        assert owner == "codeflash-ai"
+        assert repo_name == "posthog"
+
     @patch("codeflash.code_utils.git_utils.git.Repo")
     def test_check_running_in_git_repo_in_git_repo(self, mock_repo):
         mock_repo.return_value.git_dir = "/path/to/repo/.git"


### PR DESCRIPTION
### **User description**
trailing slahes were not handled properly when parsing the owner and repo


___

### **PR Type**
- Bug fix
- Tests



___

### **Description**
- Adjust repository URL parsing to handle trailing slashes.

- Remove redundant commented code in git_utils.

- Add test cases for SSH URL trailing slash scenario.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>git_utils.py</strong><dd><code>Update get_repo_owner_and_name to handle trailing slashes.</code></dd></summary>
<hr>

codeflash/code_utils/git_utils.py

<li>Added condition to handle empty string when trailing slash exists.<br> <li> Adjusted index access in URL split for proper repo owner extraction.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/156/files#diff-d3ae77a7d0c239fe9e169d37da13bc8f4f5ae8c0fe0e23a1487ed96c8e5866e5">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_git_utils.py</strong><dd><code>Add new test for trailing slash in git utils parsing.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_git_utils.py

<li>Introduced test for SSH URL with trailing slash.<br> <li> Enhanced tests for get_repo_owner_and_name consistency.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/156/files#diff-dca8d5901c13c8fdb3912ed1fa77246f037bdda082b903fac553851476779773">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>