### PR TITLE
allow benchmarking fixture to be used multiple times within a test case

### DIFF
--- a/codeflash/benchmarking/instrument_codeflash_trace.py
+++ b/codeflash/benchmarking/instrument_codeflash_trace.py
@@ -13,39 +13,35 @@ class AddDecoratorTransformer(cst.CSTTransformer):
         self.added_codeflash_trace = False
         self.class_name = ""
         self.function_name = ""
-        self.decorator = cst.Decorator(
-            decorator=cst.Name(value="codeflash_trace")
-        )
+        self.decorator = cst.Decorator(decorator=cst.Name(value="codeflash_trace"))
 
-    def leave_ClassDef(self, original_node, updated_node):
+    def leave_ClassDef(self, original_node, updated_node):  # noqa: ANN001, ANN201, N802
         if self.class_name == original_node.name.value:
-            self.class_name = "" # Even if nested classes are not visited, this function is still called on them
+            self.class_name = ""  # Even if nested classes are not visited, this function is still called on them
         return updated_node
 
-    def visit_ClassDef(self, node):
-        if self.class_name: # Don't go into nested class
+    def visit_ClassDef(self, node):  # noqa: ANN001, ANN201, N802
+        if self.class_name:  # Don't go into nested class
             return False
-        self.class_name = node.name.value
+        self.class_name = node.name.value  # noqa: RET503
 
-    def visit_FunctionDef(self, node):
-        if self.function_name: # Don't go into nested function
+    def visit_FunctionDef(self, node):  # noqa: ANN001, ANN201, N802
+        if self.function_name:  # Don't go into nested function
             return False
-        self.function_name = node.name.value
+        self.function_name = node.name.value  # noqa: RET503
 
-    def leave_FunctionDef(self, original_node, updated_node):
+    def leave_FunctionDef(self, original_node, updated_node):  # noqa: ANN001, ANN201, N802
         if self.function_name == original_node.name.value:
             self.function_name = ""
         if (self.class_name, original_node.name.value) in self.target_functions:
             # Add the new decorator after any existing decorators, so it gets executed first
-            updated_decorators = list(updated_node.decorators) + [self.decorator]
+            updated_decorators = [*list(updated_node.decorators), self.decorator]
             self.added_codeflash_trace = True
-            return updated_node.with_changes(
-                decorators=updated_decorators
-            )
+            return updated_node.with_changes(decorators=updated_decorators)
 
         return updated_node
 
-    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:
+    def leave_Module(self, original_node: cst.Module, updated_node: cst.Module) -> cst.Module:  # noqa: ARG002, N802
         # Create import statement for codeflash_trace
         if not self.added_codeflash_trace:
             return updated_node
@@ -53,17 +49,10 @@ class AddDecoratorTransformer(cst.CSTTransformer):
             body=[
                 cst.ImportFrom(
                     module=cst.Attribute(
-                        value=cst.Attribute(
-                            value=cst.Name(value="codeflash"),
-                            attr=cst.Name(value="benchmarking")
-                        ),
-                        attr=cst.Name(value="codeflash_trace")
+                        value=cst.Attribute(value=cst.Name(value="codeflash"), attr=cst.Name(value="benchmarking")),
+                        attr=cst.Name(value="codeflash_trace"),
                     ),
-                    names=[
-                        cst.ImportAlias(
-                            name=cst.Name(value="codeflash_trace")
-                        )
-                    ]
+                    names=[cst.ImportAlias(name=cst.Name(value="codeflash_trace"))],
                 )
             ]
         )
@@ -73,12 +62,13 @@ class AddDecoratorTransformer(cst.CSTTransformer):
 
         return updated_node.with_changes(body=new_body)
 
+
 def add_codeflash_decorator_to_code(code: str, functions_to_optimize: list[FunctionToOptimize]) -> str:
     """Add codeflash_trace to a function.
 
     Args:
         code: The source code as a string
-        function_to_optimize: The FunctionToOptimize instance containing function details
+        functions_to_optimize: List of FunctionToOptimize instances containing function details
 
     Returns:
         The modified source code as a string
@@ -91,27 +81,17 @@ def add_codeflash_decorator_to_code(code: str, functions_to_optimize: list[Funct
             class_name = function_to_optimize.parents[0].name
         target_functions.add((class_name, function_to_optimize.function_name))
 
-    transformer = AddDecoratorTransformer(
-        target_functions = target_functions,
-    )
+    transformer = AddDecoratorTransformer(target_functions=target_functions)
 
     module = cst.parse_module(code)
     modified_module = module.visit(transformer)
     return modified_module.code
 
 
-def instrument_codeflash_trace_decorator(
-        file_to_funcs_to_optimize: dict[Path, list[FunctionToOptimize]]
-) -> None:
+def instrument_codeflash_trace_decorator(file_to_funcs_to_optimize: dict[Path, list[FunctionToOptimize]]) -> None:
     """Instrument codeflash_trace decorator to functions to optimize."""
     for file_path, functions_to_optimize in file_to_funcs_to_optimize.items():
         original_code = file_path.read_text(encoding="utf-8")
-        new_code = add_codeflash_decorator_to_code(
-            original_code,
-            functions_to_optimize
-        )
-        # Modify the code
+        new_code = add_codeflash_decorator_to_code(original_code, functions_to_optimize)
         modified_code = isort.code(code=new_code, float_to_top=True)
-
-        # Write the modified code back to the file
         file_path.write_text(modified_code, encoding="utf-8")

--- a/codeflash/benchmarking/pytest_new_process_trace_benchmarks.py
+++ b/codeflash/benchmarking/pytest_new_process_trace_benchmarks.py
@@ -16,8 +16,20 @@ if __name__ == "__main__":
         codeflash_benchmark_plugin.setup(trace_file, project_root)
         codeflash_trace.setup(trace_file)
         exitcode = pytest.main(
-            [benchmarks_root, "--codeflash-trace", "-p", "no:benchmark","-p", "no:codspeed","-p", "no:cov-s", "-o", "addopts="], plugins=[codeflash_benchmark_plugin]
-        ) # Errors will be printed to stdout, not stderr
+            [
+                benchmarks_root,
+                "--codeflash-trace",
+                "-p",
+                "no:benchmark",
+                "-p",
+                "no:codspeed",
+                "-p",
+                "no:cov-s",
+                "-o",
+                "addopts=",
+            ],
+            plugins=[codeflash_benchmark_plugin],
+        )  # Errors will be printed to stdout, not stderr
 
     except Exception as e:
         print(f"Failed to collect tests: {e!s}", file=sys.stderr)

--- a/codeflash/benchmarking/trace_benchmarks.py
+++ b/codeflash/benchmarking/trace_benchmarks.py
@@ -9,7 +9,9 @@ from codeflash.cli_cmds.console import logger
 from codeflash.code_utils.compat import SAFE_SYS_EXECUTABLE
 
 
-def trace_benchmarks_pytest(benchmarks_root: Path, tests_root:Path, project_root: Path, trace_file: Path, timeout:int = 300) -> None:
+def trace_benchmarks_pytest(
+    benchmarks_root: Path, tests_root: Path, project_root: Path, trace_file: Path, timeout: int = 300
+) -> None:
     benchmark_env = os.environ.copy()
     if "PYTHONPATH" not in benchmark_env:
         benchmark_env["PYTHONPATH"] = str(project_root)
@@ -43,6 +45,4 @@ def trace_benchmarks_pytest(benchmarks_root: Path, tests_root:Path, project_root
             error_section = match.group(1) if match else result.stdout
         else:
             error_section = result.stdout
-        logger.warning(
-            f"Error collecting benchmarks - Pytest Exit code: {result.returncode}, {error_section}"
-        )
+        logger.warning(f"Error collecting benchmarks - Pytest Exit code: {result.returncode}, {error_section}")

--- a/codeflash/code_utils/code_utils.py
+++ b/codeflash/code_utils/code_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import os
+import shutil
 import site
 from functools import lru_cache
 from pathlib import Path
@@ -118,4 +119,9 @@ def has_any_async_functions(code: str) -> bool:
 
 def cleanup_paths(paths: list[Path]) -> None:
     for path in paths:
-        path.unlink(missing_ok=True)
+        if not path or not path.exists():
+            continue
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink(missing_ok=True)

--- a/codeflash/discovery/functions_to_optimize.py
+++ b/codeflash/discovery/functions_to_optimize.py
@@ -201,6 +201,7 @@ def get_functions_to_optimize(
             functions, test_cfg.tests_root, ignore_paths, project_root, module_root
         )
         logger.info(f"Found {functions_count} function{'s' if functions_count > 1 else ''} to optimize")
+        console.rule()
         return filtered_modified_functions, functions_count
 
 

--- a/codeflash/optimization/optimizer.py
+++ b/codeflash/optimization/optimizer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import os
-import shutil
 import tempfile
 import time
 from collections import defaultdict
@@ -18,7 +17,7 @@ from codeflash.benchmarking.utils import print_benchmark_table, validate_and_for
 from codeflash.cli_cmds.console import console, logger, progress_bar
 from codeflash.code_utils import env_utils
 from codeflash.code_utils.code_replacer import normalize_code, normalize_node
-from codeflash.code_utils.code_utils import get_run_tmp_file
+from codeflash.code_utils.code_utils import cleanup_paths, get_run_tmp_file
 from codeflash.code_utils.static_analysis import analyze_imported_modules, get_first_top_level_function_or_method_ast
 from codeflash.discovery.discover_unit_tests import discover_unit_tests
 from codeflash.discovery.functions_to_optimize import get_functions_to_optimize
@@ -52,6 +51,11 @@ class Optimizer:
         self.experiment_id = os.getenv("CODEFLASH_EXPERIMENT_ID", None)
         self.local_aiservice_client = LocalAiServiceClient() if self.experiment_id else None
         self.replay_tests_dir = None
+
+        self.test_cfg.concolic_test_root_dir = Path(
+            tempfile.mkdtemp(dir=self.args.tests_root, prefix="codeflash_concolic_")
+        )
+
     def create_function_optimizer(
         self,
         function_to_optimize: FunctionToOptimize,
@@ -71,7 +75,7 @@ class Optimizer:
             args=self.args,
             function_benchmark_timings=function_benchmark_timings if function_benchmark_timings else None,
             total_benchmark_timings=total_benchmark_timings if total_benchmark_timings else None,
-            replay_tests_dir = self.replay_tests_dir
+            replay_tests_dir=self.replay_tests_dir,
         )
 
     def run(self) -> None:
@@ -81,6 +85,7 @@ class Optimizer:
         if not env_utils.ensure_codeflash_api_key():
             return
         function_optimizer = None
+        trace_file = None
         file_to_funcs_to_optimize: dict[Path, list[FunctionToOptimize]]
         num_optimizable_functions: int
 
@@ -98,10 +103,7 @@ class Optimizer:
         function_benchmark_timings: dict[str, dict[BenchmarkKey, int]] = {}
         total_benchmark_timings: dict[BenchmarkKey, int] = {}
         if self.args.benchmark and num_optimizable_functions > 0:
-            with progress_bar(
-                    f"Running benchmarks in {self.args.benchmarks_root}",
-                    transient=True,
-            ):
+            with progress_bar(f"Running benchmarks in {self.args.benchmarks_root}", transient=True):
                 # Insert decorator
                 file_path_to_source_code = defaultdict(str)
                 for file in file_to_funcs_to_optimize:
@@ -113,15 +115,23 @@ class Optimizer:
                     if trace_file.exists():
                         trace_file.unlink()
 
-                    self.replay_tests_dir = Path(tempfile.mkdtemp(prefix="codeflash_replay_tests_", dir=self.args.benchmarks_root))
-                    trace_benchmarks_pytest(self.args.benchmarks_root, self.args.tests_root, self.args.project_root, trace_file) # Run all tests that use pytest-benchmark
+                    self.replay_tests_dir = Path(
+                        tempfile.mkdtemp(prefix="codeflash_replay_tests_", dir=self.args.benchmarks_root)
+                    )
+                    trace_benchmarks_pytest(
+                        self.args.benchmarks_root, self.args.tests_root, self.args.project_root, trace_file
+                    )  # Run all tests that use pytest-benchmark
                     replay_count = generate_replay_test(trace_file, self.replay_tests_dir)
                     if replay_count == 0:
-                        logger.info(f"No valid benchmarks found in {self.args.benchmarks_root} for functions to optimize, continuing optimization")
+                        logger.info(
+                            f"No valid benchmarks found in {self.args.benchmarks_root} for functions to optimize, continuing optimization"
+                        )
                     else:
                         function_benchmark_timings = CodeFlashBenchmarkPlugin.get_function_benchmark_timings(trace_file)
                         total_benchmark_timings = CodeFlashBenchmarkPlugin.get_benchmark_timings(trace_file)
-                        function_to_results = validate_and_format_benchmark_table(function_benchmark_timings, total_benchmark_timings)
+                        function_to_results = validate_and_format_benchmark_table(
+                            function_benchmark_timings, total_benchmark_timings
+                        )
                         print_benchmark_table(function_to_results)
                 except Exception as e:
                     logger.info(f"Error while tracing existing benchmarks: {e}")
@@ -131,12 +141,9 @@ class Optimizer:
                     for file in file_path_to_source_code:
                         with file.open("w", encoding="utf8") as f:
                             f.write(file_path_to_source_code[file])
+                    self.cleanup()
         optimizations_found: int = 0
         function_iterator_count: int = 0
-        if self.args.test_framework == "pytest":
-            self.test_cfg.concolic_test_root_dir = Path(
-                tempfile.mkdtemp(dir=self.args.tests_root, prefix="codeflash_concolic_")
-            )
         try:
             ph("cli-optimize-functions-to-optimize", {"num_functions": num_optimizable_functions})
             if num_optimizable_functions == 0:
@@ -148,10 +155,11 @@ class Optimizer:
             function_to_tests: dict[str, list[FunctionCalledInTest]] = discover_unit_tests(self.test_cfg)
             num_discovered_tests: int = sum([len(value) for value in function_to_tests.values()])
             console.rule()
-            logger.info(f"Discovered {num_discovered_tests} existing unit tests in {(time.time() - start_time):.1f}s at {self.test_cfg.tests_root}")
+            logger.info(
+                f"Discovered {num_discovered_tests} existing unit tests in {(time.time() - start_time):.1f}s at {self.test_cfg.tests_root}"
+            )
             console.rule()
             ph("cli-optimize-discovered-tests", {"num_tests": num_discovered_tests})
-
 
             for original_module_path in file_to_funcs_to_optimize:
                 logger.info(f"Examining file {original_module_path!s}…")
@@ -212,14 +220,26 @@ class Optimizer:
                     qualified_name_w_module = function_to_optimize.qualified_name_with_modules_from_root(
                         self.args.project_root
                     )
-                    if self.args.benchmark and function_benchmark_timings and qualified_name_w_module in function_benchmark_timings and total_benchmark_timings:
+                    if (
+                        self.args.benchmark
+                        and function_benchmark_timings
+                        and qualified_name_w_module in function_benchmark_timings
+                        and total_benchmark_timings
+                    ):
                         function_optimizer = self.create_function_optimizer(
-                            function_to_optimize, function_to_optimize_ast, function_to_tests, validated_original_code[original_module_path].source_code, function_benchmark_timings[qualified_name_w_module], total_benchmark_timings
+                            function_to_optimize,
+                            function_to_optimize_ast,
+                            function_to_tests,
+                            validated_original_code[original_module_path].source_code,
+                            function_benchmark_timings[qualified_name_w_module],
+                            total_benchmark_timings,
                         )
                     else:
                         function_optimizer = self.create_function_optimizer(
-                            function_to_optimize, function_to_optimize_ast, function_to_tests,
-                            validated_original_code[original_module_path].source_code
+                            function_to_optimize,
+                            function_to_optimize_ast,
+                            function_to_tests,
+                            validated_original_code[original_module_path].source_code,
                         )
 
                     best_optimization = function_optimizer.optimize_function()
@@ -235,23 +255,44 @@ class Optimizer:
             elif self.args.all:
                 logger.info("✨ All functions have been optimized! ✨")
         finally:
-            if function_optimizer:
-                for test_file in function_optimizer.test_files.get_by_type(TestType.GENERATED_REGRESSION).test_files:
-                    test_file.instrumented_behavior_file_path.unlink(missing_ok=True)
-                    test_file.benchmarking_file_path.unlink(missing_ok=True)
-                for test_file in function_optimizer.test_files.get_by_type(TestType.EXISTING_UNIT_TEST).test_files:
-                    test_file.instrumented_behavior_file_path.unlink(missing_ok=True)
-                    test_file.benchmarking_file_path.unlink(missing_ok=True)
-                for test_file in function_optimizer.test_files.get_by_type(TestType.CONCOLIC_COVERAGE_TEST).test_files:
-                    test_file.instrumented_behavior_file_path.unlink(missing_ok=True)
-                if function_optimizer.test_cfg.concolic_test_root_dir:
-                    shutil.rmtree(function_optimizer.test_cfg.concolic_test_root_dir, ignore_errors=True)
-                if self.args.benchmark:
-                    if self.replay_tests_dir.exists():
-                        shutil.rmtree(self.replay_tests_dir, ignore_errors=True)
-                    trace_file.unlink(missing_ok=True)
-            if hasattr(get_run_tmp_file, "tmpdir"):
-                get_run_tmp_file.tmpdir.cleanup()
+            self.cleanup(function_optimizer=function_optimizer)
+
+    def cleanup(self, function_optimizer: FunctionOptimizer | None = None) -> None:
+        paths_to_cleanup: list[Path] = []
+        if function_optimizer:
+            paths_to_cleanup.extend(
+                test_file.instrumented_behavior_file_path
+                for test_file in function_optimizer.test_files.get_by_type(TestType.GENERATED_REGRESSION).test_files
+            )
+            paths_to_cleanup.extend(
+                test_file.benchmarking_file_path
+                for test_file in function_optimizer.test_files.get_by_type(TestType.GENERATED_REGRESSION).test_files
+            )
+            paths_to_cleanup.extend(
+                test_file.instrumented_behavior_file_path
+                for test_file in function_optimizer.test_files.get_by_type(TestType.EXISTING_UNIT_TEST).test_files
+            )
+            paths_to_cleanup.extend(
+                test_file.benchmarking_file_path
+                for test_file in function_optimizer.test_files.get_by_type(TestType.EXISTING_UNIT_TEST).test_files
+            )
+            paths_to_cleanup.extend(
+                test_file.instrumented_behavior_file_path
+                for test_file in function_optimizer.test_files.get_by_type(TestType.CONCOLIC_COVERAGE_TEST).test_files
+            )
+            paths_to_cleanup.extend(
+                test_file.benchmarking_file_path
+                for test_file in function_optimizer.test_files.get_by_type(TestType.REPLAY_TEST).test_files
+            )
+
+        paths_to_cleanup.extend(
+            path for path in {self.replay_tests_dir, self.test_cfg.concolic_test_root_dir} if path and path.exists()
+        )
+
+        cleanup_paths(paths_to_cleanup)
+
+        if hasattr(get_run_tmp_file, "tmpdir"):
+            get_run_tmp_file.tmpdir.cleanup()
 
 
 def run_with_args(args: Namespace) -> None:

--- a/codeflash/verification/parse_test_output.py
+++ b/codeflash/verification/parse_test_output.py
@@ -66,7 +66,11 @@ def parse_test_return_values_bin(file_location: Path, test_files: TestFiles, tes
                 len_next_bytes = file.read(4)
                 len_next = int.from_bytes(len_next_bytes, byteorder="big")
                 invocation_id_bytes = file.read(len_next)
-                invocation_id = invocation_id_bytes.decode("ascii")
+                try:
+                    invocation_id = invocation_id_bytes.decode("ascii")
+                except UnicodeDecodeError as e:
+                    logger.warning(f"Failed to decode invocation_id_bytes as ASCII in {file_location}: {e}. Skipping entry.")
+                    continue
 
                 invocation_id_object = InvocationId.from_str_id(encoded_test_name, invocation_id)
                 test_file_path = file_path_from_module_name(


### PR DESCRIPTION
### **User description**
currently, if we want to benchmark a function which has arguments which can be permuted, such as 
```py
def _aggregate_images_shape(
    images: List[np.ndarray], mode: Literal["min", "max", "avg"]
) -> Tuple[int, int]:
    if mode not in SHAPE_AGGREGATION_FUN:
        raise ValueError(
            f"Could not aggregate images shape - provided unknown mode: {mode}. "
            f"Supported modes: {list(SHAPE_AGGREGATION_FUN.keys())}."
        )
    return SHAPE_AGGREGATION_FUN[mode](images)
```

we would have to express it as 
```py
def test_calculate_aggregated_images_shape_min(benchmark, dataset_reference):
    images, image_sizes = dataset_reference
    benchmark(
        _aggregate_images_shape,
        images,
        "min",
    )


def test_calculate_aggregated_images_shape_max(benchmark, dataset_reference):
    images, image_sizes = dataset_reference
    benchmark(
        _aggregate_images_shape,
        images,
        "max",
    )


def test_calculate_aggregated_images_shape_avg(benchmark, dataset_reference):
    images, image_sizes = dataset_reference
    benchmark(
        _aggregate_images_shape,
        images,
        "avg",
    )
```

instead, a more concise way of expressing it is:

```
def test_calculate_aggregated_images_shape(benchmark, dataset_reference):
    images, image_sizes = dataset_reference
    for mode in ["min", "max", "avg"]:
        benchmark(
            _aggregate_images_shape,
            images,
            mode,
            benchmark_name_suffix=f"mode_{mode}",
        )
```

and 
```py
def test_is_prediction_registration_forbidden(benchmark):
    predictions: list[Prediction] = [
        {"predictions": [{"x": 37}], "top": "cat"},
        {"top": "cat"},
        {"predictions": []},
        {"is_stub": True},
        {},
    ]
    persist_options = [True, False]
    roboflow_image_id_options = ["some_id", None]

    param_combinations = itertools.product(
        predictions,
        persist_options,
        roboflow_image_id_options,
    )

    for i, (prediction, persist, roboflow_image_id) in enumerate(param_combinations):
        benchmark(
            is_prediction_registration_forbidden,
            prediction=prediction,
            persist_predictions=persist,
            roboflow_image_id=roboflow_image_id,
            benchmark_name_suffix=(
                f"prediction_case_{i}_"
                f"persist_{persist}_"
                f"has_image_id_{roboflow_image_id is not None}"
            ),
        )
```
for more complicated cases


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
Replace prints with logger for consistent logging
Support multiple benchmark calls in single test
Add call counters and benchmark name suffix
Introduce cleanup logic for temporary artifacts


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>codeflash_trace.py</strong><dd><code>Use logger instead of print in tracing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-55978ea67eb47996aeddafe30c8e86a644b384e918acdd60776428c776aa1a7c">+52/-25</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>instrument_codeflash_trace.py</strong><dd><code>Refactor decorator insertion formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-ee73cf5b9dbab68924156c645c5b46eba72dcfb02b303ee2d305686923de3346">+21/-41</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>pytest_new_process_trace_benchmarks.py</strong><dd><code>Adjust pytest invocation argument formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-c960728d6fef3c0b7a420f4414d8c803c9abcaf87fe4c3c8ee8cb86695da099f">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>plugin.py</strong><dd><code>Improve pytest plugin logging and fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-17c54b346432c9145edb49dd0c82b133160918353c32fbb02a0b0f4a84fc3d16">+49/-67</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>trace_benchmarks.py</strong><dd><code>Simplify error logging in benchmark collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-10e89f6d48fdc972da927f2c77d34acbfb711f239df5a0d87a4802d49d8b2685">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>utils.py</strong><dd><code>Add recursive cleanup and console integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-c3dac95c7674a17acf3b63d29e7e78bc7b9907fa45ac4076b330470dc037e4dc">+48/-41</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>code_utils.py</strong><dd><code>Extend cleanup_paths to remove directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-535eb86ee56c00a68a21693d0fcf3b6a416eb0b73dd5646c4e574365e70e89a8">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>functions_to_optimize.py</strong><dd><code>Log function count with console rule separator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-adb17c14509d2bdc69ea39d82dfdde9c4c1c30277f9c8765b74ebb016b0c3cb3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>optimizer.py</strong><dd><code>Refactor optimization cleanup logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-d242b27fa098f222741a48a7daa8e421433b4c5e19dd38512404cd000df144a0">+77/-38</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>replay_test.py</strong><dd><code>Fix SQL query execution and formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/169/files#diff-98406687d8fefcb473ae890994fe8bdccf0a488dadf5f2a663d93184831c7c65">+42/-44</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>