### PR TITLE
no benchmark option on top

### DIFF
--- a/codeflash/LICENSE
+++ b/codeflash/LICENSE
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             CodeFlash Inc.
-Licensed Work:        Codeflash Client version 0.10.x
+Licensed Work:        Codeflash Client version 0.12.x
                       The Licensed Work is (c) 2024 CodeFlash Inc.
 
 Additional Use Grant: None. Production use of the Licensed Work is only permitted
@@ -13,7 +13,7 @@ Additional Use Grant: None. Production use of the Licensed Work is only permitte
                       Platform. Please visit codeflash.ai for further
                       information.
 
-Change Date:          2029-02-25
+Change Date:          2029-04-23
 
 Change License:       MIT
 

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -255,12 +255,13 @@ def collect_setup_info() -> SetupInfo:
         tests_subdirs = [d.name for d in tests_root.iterdir() if d.is_dir() and not d.name.startswith(".")]
 
     benchmarks_options = []
+    benchmarks_options.append(no_benchmarks_option)
     if default_benchmarks_subdir in tests_subdirs:
         benchmarks_options.append(default_benchmarks_subdir)
     benchmarks_options.extend([d for d in tests_subdirs if d != default_benchmarks_subdir])
     benchmarks_options.append(create_benchmarks_option)
     benchmarks_options.append(custom_dir_option)
-    benchmarks_options.append(no_benchmarks_option)
+
 
     benchmarks_answer = inquirer_wrapper(
         inquirer.list_input,

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -160,7 +160,7 @@ def collect_setup_info() -> SetupInfo:
     # Check for the existence of pyproject.toml or setup.py
     project_name = check_for_toml_or_setup_file()
 
-    ignore_subdirs = ["venv", "node_modules", "dist", "build", "build_temp", "build_scripts", "env", "logs", "tmp"]
+    ignore_subdirs = ["venv", "node_modules", "dist", "build", "build_temp", "build_scripts", "env", "logs", "tmp", "__pycache__"]
     valid_subdirs = [
         d for d in next(os.walk("."))[1] if not d.startswith(".") and not d.startswith("__") and d not in ignore_subdirs
     ]
@@ -258,7 +258,7 @@ def collect_setup_info() -> SetupInfo:
     benchmarks_options.append(no_benchmarks_option)
     if default_benchmarks_subdir in tests_subdirs:
         benchmarks_options.append(default_benchmarks_subdir)
-    benchmarks_options.extend([d for d in tests_subdirs if d != default_benchmarks_subdir])
+    benchmarks_options.extend([d for d in tests_subdirs if d != default_benchmarks_subdir and d not in ignore_subdirs])
     benchmarks_options.append(create_benchmarks_option)
     benchmarks_options.append(custom_dir_option)
 

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -265,7 +265,7 @@ def collect_setup_info() -> SetupInfo:
 
     benchmarks_answer = inquirer_wrapper(
         inquirer.list_input,
-        message="Where are your benchmarks located? (benchmarks must be a sub directory of your tests root directory)",
+        message="Where are your performance benchmarks located? (benchmarks must be a sub directory of your tests root directory)",
         choices=benchmarks_options,
         default=(
             default_benchmarks_subdir if default_benchmarks_subdir in benchmarks_options else benchmarks_options[0]),

--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced by poetry-dynamic-versioning during `poetry build`.
-__version__ = "0.12.0"
-__version_tuple__ = (0, 12, 0)
+__version__ = "0.12.0.post4.dev0+4bc590a8"
+__version_tuple__ = (0, 12, 0, "post4", "dev0", "4bc590a8")

--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced by poetry-dynamic-versioning during `poetry build`.
-__version__ = "0.12.0.post4.dev0+4bc590a8"
-__version_tuple__ = (0, 12, 0, "post4", "dev0", "4bc590a8")
+__version__ = "0.12.0"
+__version_tuple__ = (0, 12, 0)


### PR DESCRIPTION
### **User description**
most repos won't have benchmarks so it makes sense to have the no benchmark option on top


___

### **PR Type**
Enhancement


___

### **Description**
- Prepend `no_benchmarks_option` to benchmarks list


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cmd_init.py</strong><dd><code>Reorder no-benchmarks option to top</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cmd_init.py

<li>Append <code>no_benchmarks_option</code> at start of <code>benchmarks_options</code><br> <li> Remove the duplicate append of <code>no_benchmarks_option</code> at end


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/170/files#diff-c15be1c100e57b623163c38b4995067f137d3ad0cf5c3e8cebeaa2f32ef86fc8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>