### PR TITLE
Prevent large inputs in tracer tests

### DIFF
--- a/code_to_optimize/code_directories/simple_tracer_e2e/workload.py
+++ b/code_to_optimize/code_directories/simple_tracer_e2e/workload.py
@@ -2,8 +2,8 @@ from concurrent.futures import ThreadPoolExecutor
 
 
 def funcA(number):
-    if number>100:
-        number=100
+    if number>1000:
+        number=1000
     if number<1:
         number=1
     k = 0

--- a/code_to_optimize/code_directories/simple_tracer_e2e/workload.py
+++ b/code_to_optimize/code_directories/simple_tracer_e2e/workload.py
@@ -2,10 +2,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 
 def funcA(number):
-    if number>1000:
-        number=1000
-    if number<1:
-        number=1
+    number = number if number < 1000 else 1000
     k = 0
     for i in range(number * 100):
         k += i

--- a/code_to_optimize/code_directories/simple_tracer_e2e/workload.py
+++ b/code_to_optimize/code_directories/simple_tracer_e2e/workload.py
@@ -2,6 +2,10 @@ from concurrent.futures import ThreadPoolExecutor
 
 
 def funcA(number):
+    if number>100:
+        number=100
+    if number<1:
+        number=1
     k = 0
     for i in range(number * 100):
         k += i

--- a/tests/scripts/end_to_end_test_tracer_replay.py
+++ b/tests/scripts/end_to_end_test_tracer_replay.py
@@ -10,7 +10,7 @@ def run_test(expected_improvement_pct: int) -> bool:
         min_improvement_x=0.1,
         expected_unit_tests=1,
         coverage_expectations=[
-            CoverageExpectation(function_name="funcA", expected_coverage=100.0, expected_lines=[5, 6, 7, 9, 12]),
+            CoverageExpectation(function_name="funcA", expected_coverage=100.0, expected_lines=[5, 6, 7, 8, 9, 12]),
         ],
     )
     cwd = (

--- a/tests/scripts/end_to_end_test_tracer_replay.py
+++ b/tests/scripts/end_to_end_test_tracer_replay.py
@@ -10,7 +10,7 @@ def run_test(expected_improvement_pct: int) -> bool:
         min_improvement_x=0.1,
         expected_unit_tests=1,
         coverage_expectations=[
-            CoverageExpectation(function_name="funcA", expected_coverage=100.0, expected_lines=[5, 6, 7, 8, 9, 12]),
+            CoverageExpectation(function_name="funcA", expected_coverage=100.0, expected_lines=[5, 6, 7, 8, 10, 13]),
         ],
     )
     cwd = (


### PR DESCRIPTION
### **User description**
Clipping number between 1 and 100


___

### **PR Type**
Bug fix


___

### **Description**
- Clamp `number` input to [1,100]


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workload.py</strong><dd><code>Clamp `number` to valid range</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

code_to_optimize/code_directories/simple_tracer_e2e/workload.py

<li>Added input clamping for <code>number</code><br> <li> Ensured <code>number</code> stays within 1-100 bounds


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/192/files#diff-20a09d19079d2927ec1938325183c71b88674de9193eeb93770247b0b0c696e3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>