### PR TITLE
Codeflash Capture should not depend on anything inside codeflash

### DIFF
--- a/codeflash/models/models.py
+++ b/codeflash/models/models.py
@@ -364,7 +364,7 @@ class TestingMode(enum.Enum):
     PERFORMANCE = "performance"
     LINE_PROFILE = "line_profile"
 
-
+#TODO this class is duplicated in codeflash_capture
 class VerificationType(str, Enum):
     FUNCTION_CALL = (
         "function_call"  # Correctness verification for a test function, checks input values and output values)

--- a/codeflash/verification/codeflash_capture.py
+++ b/codeflash/verification/codeflash_capture.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# This file should not have any dependencies on codeflash
 import functools
 import gc
 import inspect
@@ -7,10 +8,15 @@ import os
 import sqlite3
 import time
 from pathlib import Path
-
+from enum import Enum
 import dill as pickle
 
-from codeflash.models.models import VerificationType
+class VerificationType(str, Enum):
+    FUNCTION_CALL = (
+        "function_call"  # Correctness verification for a test function, checks input values and output values)
+    )
+    INIT_STATE_FTO = "init_state_fto"  # Correctness verification for fto class instance attributes after init
+    INIT_STATE_HELPER = "init_state_helper"  # Correctness verification for helper class instance attributes after init
 
 
 def get_test_info_from_stack(tests_root: str) -> tuple[str, str | None, str, str]:


### PR DESCRIPTION
### **User description**
It leads to circular dependencies when running tests.


___

### **PR Type**
Enhancement


___

### **Description**
- Decouple capture module from codeflash dependencies.

- Inline `VerificationType` enum within module.

- Remove external import from codeflash.models.models.

- Add header comment preventing internal dependencies.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codeflash_capture.py</strong><dd><code>Inline VerificationType enum, remove external dependency</code>&nbsp; </dd></summary>
<hr>

codeflash/verification/codeflash_capture.py

<li>Added header comment preventing internal dependencies.<br> <li> Imported <code>Enum</code> locally and removed external import.<br> <li> Inlined <code>VerificationType</code> enum in module.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/196/files#diff-889170db85c68da82162194c60bb86e2fd376680ae060b678de901e5f97f055d">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>