### PR TITLE
Python 'range' objects can be compared with double equal

### DIFF
--- a/codeflash/verification/comparator.py
+++ b/codeflash/verification/comparator.py
@@ -84,6 +84,7 @@ def comparator(orig: Any, new: Any, superset_obj=False) -> bool:
                 frozenset,
                 enum.Enum,
                 type,
+                range
             ),
         ):
             return orig == new

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -125,11 +125,21 @@ def test_basic_python_objects() -> None:
     assert comparator(a, b)
     assert not comparator(a, c)
 
-    a = range(1,10)
-    b = range(1,10)
-    c = range(1,20)
-    assert comparator(a, b)
-    assert not comparator(a, c)
+@pytest.mark.parametrize("r1, r2, expected", [
+    (range(1, 10), range(1, 10), True),                # equal
+    (range(0, 10), range(1, 10), False),               # different start
+    (range(2, 10), range(1, 10), False),
+    (range(1, 5), range(1, 10), False),                # different stop
+    (range(1, 20), range(1, 10), False),
+    (range(1, 10, 1), range(1, 10, 2), False),          # different step
+    (range(1, 10, 3), range(1, 10, 2), False),
+    (range(-5, 0), range(-5, 0), True),                # negative ranges
+    (range(-10, 0), range(-5, 0), False),
+    (range(5, 1), range(10, 5), True),                # empty ranges
+    (range(5, 1), range(5, 1), True),
+])
+def test_ranges(r1, r2, expected):
+    assert comparator(r1, r2) == expected
 
 
 def test_standard_python_library_objects() -> None:

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -125,6 +125,12 @@ def test_basic_python_objects() -> None:
     assert comparator(a, b)
     assert not comparator(a, c)
 
+    a = range(1,10)
+    b = range(1,10)
+    c = range(1,20)
+    assert comparator(a, b)
+    assert not comparator(a, c)
+
 
 def test_standard_python_library_objects() -> None:
     a = datetime.datetime(2020, 2, 2, 2, 2, 2) # type: ignore

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -137,7 +137,11 @@ def test_basic_python_objects() -> None:
     (range(-10, 0), range(-5, 0), False),
     (range(5, 1), range(10, 5), True),                # empty ranges
     (range(5, 1), range(5, 1), True),
+    (range(7), range(0, 7), True),
+    (range(0, 7), range(0, 7, 1), True),
+    (range(7), range(0, 7, 1), True),
 ])
+
 def test_ranges(r1, r2, expected):
     assert comparator(r1, r2) == expected
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Support range object comparisons.

- Add tests for range comparisons.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comparator.py</strong><dd><code>Add range support in comparator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/verification/comparator.py

<li>Added <code>range</code> to simple types tuple<br> <li> Now compares <code>range</code> using <code>==</code>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/201/files#diff-a6f2493dbc3f1ec576d03e2d188986f94ca475e3b4cf79ba3dff06309ec01997">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_comparator.py</strong><dd><code>Add tests for range comparisons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_comparator.py

<li>Added tests comparing equal <code>range</code> objects<br> <li> Assert inequality for different <code>range</code>s


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/201/files#diff-8a94135d1fe94202dcb23b0217c1f7ef21d422d3a72c337836ba3fc85c17dfa6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>