### PR TITLE
Fixing `codeflash init` for Python 3.9 (CF-649)

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, Union
 
 import click
 import git
@@ -50,7 +50,7 @@ CODEFLASH_LOGO: str = (
 class SetupInfo:
     module_root: str
     tests_root: str
-    benchmarks_root: str | None
+    benchmarks_root: Union[str, None]
     test_framework: str
     ignore_paths: list[str]
     formatter: str


### PR DESCRIPTION
### **User description**
Using older type hints supported by Python 3.9


___

### **PR Type**
Bug fix


___

### **Description**
- Added `Union` import for typing compatibility 

- Replaced PEP 604 type hint with `Union`

- Ensures `codeflash init` runs on Python 3.9


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cmd_init.py</strong><dd><code>Use `Union` for optional type hints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cmd_init.py

<li>Added <code>Union</code> import from <code>typing</code><br> <li> Replaced <code>str | None</code> with <code>Union[str, None]</code> for <code>benchmarks_root</code>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/239/files#diff-c15be1c100e57b623163c38b4995067f137d3ad0cf5c3e8cebeaa2f32ef86fc8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>