### PR TITLE
propagate cf-api errors

### DIFF
--- a/codeflash/api/cfapi.py
+++ b/codeflash/api/cfapi.py
@@ -179,19 +179,10 @@ def get_blocklisted_functions() -> dict[str, set[str]] | dict[str, Any]:
     if pr_number is None:
         return {}
 
-    not_found = 404
-    internal_server_error = 500
-
     owner, repo = get_repo_owner_and_name()
     information = {"pr_number": pr_number, "repo_owner": owner, "repo_name": repo}
     try:
         req = make_cfapi_request(endpoint="/verify-existing-optimizations", method="POST", payload=information)
-        if req.status_code == not_found:
-            logger.debug(req.json()["message"])
-            return {}
-        if req.status_code == internal_server_error:
-            logger.error(req.json()["message"])
-            return {}
         req.raise_for_status()
         content: dict[str, list[str]] = req.json()
     except Exception as e:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove custom 404 and 500 handlers

- Rely on `req.raise_for_status()` for errors

- Eliminate unused status code variables


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cfapi.py</strong><dd><code>Simplify error handling in get_blocklisted_functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/api/cfapi.py

<li>Deleted <code>not_found</code> and <code>internal_server_error</code> variables<br> <li> Removed special-case 404/500 conditional blocks<br> <li> Now uses <code>req.raise_for_status()</code> for all HTTP errors


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/241/files#diff-4db91bebdd89f96b3b270c5169a5b35a98b0be8806758e0e8e055d7aacf6d4a5">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>