### PR TITLE
ensure type hints are reachable for nodes

### DIFF
--- a/codeflash/code_utils/static_analysis.py
+++ b/codeflash/code_utils/static_analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, get_type_hints
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -159,3 +159,12 @@ def has_typed_parameters(node: ast.FunctionDef | ast.AsyncFunctionDef, parents: 
     if kind in [FunctionKind.CLASS_METHOD, FunctionKind.INSTANCE_METHOD]:
         return all(arg.annotation for arg in node.args.args[1:])
     return False
+
+
+def type_hints_reachable(node: ast.AST) -> bool:
+    try:
+        get_type_hints(node)
+    except Exception:
+        return False
+    else:
+        return True

--- a/codeflash/verification/concolic_testing.py
+++ b/codeflash/verification/concolic_testing.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from codeflash.cli_cmds.console import console, logger
 from codeflash.code_utils.compat import SAFE_SYS_EXECUTABLE
 from codeflash.code_utils.concolic_utils import clean_concolic_tests
-from codeflash.code_utils.static_analysis import has_typed_parameters
+from codeflash.code_utils.static_analysis import has_typed_parameters, type_hints_reachable
 from codeflash.discovery.discover_unit_tests import discover_unit_tests
 from codeflash.telemetry.posthog_cf import ph
 from codeflash.verification.verification_utils import TestConfig
@@ -32,6 +32,7 @@ def generate_concolic_tests(
         test_cfg.concolic_test_root_dir
         and isinstance(function_to_optimize_ast, (ast.FunctionDef, ast.AsyncFunctionDef))
         and has_typed_parameters(function_to_optimize_ast, function_to_optimize.parents)
+        and type_hints_reachable(function_to_optimize_ast)
     ):
         logger.info("Generating concolic opcode coverage tests for the original code…")
         console.rule()

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -7,6 +7,7 @@ from codeflash.code_utils.static_analysis import (
     analyze_imported_modules,
     function_kind,
     has_typed_parameters,
+    type_hints_reachable,
 )
 from codeflash.models.models import FunctionParent
 
@@ -100,3 +101,17 @@ def a_function(self, a) -> None:
     parents6 = [FunctionParent(name="a_class", type="ClassDef")]
     assert function_kind(node6, parents6) == FunctionKind.CLASS_METHOD
     assert not has_typed_parameters(node6, parents6)
+
+    code7 = """
+import pandas as pd
+from typing import get_type_hints
+"""
+
+    assert type_hints_reachable(code7) is False
+
+    code = """
+import numpy as np
+def foo(x, y):
+    return x + y
+"""
+    assert type_hints_reachable(code) is False


### PR DESCRIPTION
Crosshair needs the type hints to be reachable, we can avoid a subprocess call by just defensively checking if all the nodes have their type hints reachable