### PR TITLE
remove set while runnin formatters

### DIFF
--- a/codeflash/code_utils/formatter.py
+++ b/codeflash/code_utils/formatter.py
@@ -22,7 +22,7 @@ def format_code(formatter_cmds: list[str], path: Path) -> str:
     if formatter_name == "disabled":
         return path.read_text(encoding="utf8")
     file_token = "$file"  # noqa: S105
-    for command in set(formatter_cmds):
+    for command in formatter_cmds:
         formatter_cmd_list = shlex.split(command, posix=os.name != "nt")
         formatter_cmd_list = [path.as_posix() if chunk == file_token else chunk for chunk in formatter_cmd_list]
         try:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Preserve formatter sequence order

- Remove set-based deduplication of commands

- Iterate original formatter_cmds list directly

- Allow duplicate formatter invocations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>formatter.py</strong><dd><code>Preserve formatter commands order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/formatter.py

<li>Removed use of set() around formatter_cmds<br> <li> Changed loop to iterate original list<br> <li> Preserved command order and duplicates


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/252/files#diff-ead54b6ab4522d27ae1bc0af93885ab05a8f49ea3c96308972c17deaa97515d2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>