### PR TITLE
Refactor checking of formatter by using existing function `format_code`

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -721,7 +721,7 @@ def configure_pyproject_toml(setup_info: SetupInfo) -> None:
         )
     elif formatter == "don't use a formatter":
         formatter_cmds.append("disabled")
-    check_formatter_installed(formatter_cmds)
+    check_formatter_installed(formatter_cmds, exit_on_failure="no")
     codeflash_section["formatter-cmds"] = formatter_cmds
     # Add the 'codeflash' section, ensuring 'tool' section exists
     tool_section = pyproject_data.get("tool", tomlkit.table())

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -721,7 +721,7 @@ def configure_pyproject_toml(setup_info: SetupInfo) -> None:
         )
     elif formatter == "don't use a formatter":
         formatter_cmds.append("disabled")
-    check_formatter_installed(formatter_cmds, exit_on_failure="no")
+    check_formatter_installed(formatter_cmds, exit_on_failure=False)
     codeflash_section["formatter-cmds"] = formatter_cmds
     # Add the 'codeflash' section, ensuring 'tool' section exists
     tool_section = pyproject_data.get("tool", tomlkit.table())

--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -12,7 +12,7 @@ from codeflash.code_utils.formatter import format_code
 from codeflash.code_utils.shell_utils import read_api_key_from_shell_config
 
 
-def check_formatter_installed(formatter_cmds: list[str]) -> bool:
+def check_formatter_installed(formatter_cmds: list[str], exit_on_failure: str = "yes") -> bool:
     return_code = True
     if formatter_cmds[0] == "disabled":
         return return_code
@@ -27,7 +27,8 @@ def check_formatter_installed(formatter_cmds: list[str]) -> bool:
             print(
                 "⚠️ Codeflash requires a code formatter to be installed in your environment, but none was found. Please install a supported formatter, verify the formatter-cmds in your codeflash pyproject.toml config and try again."
             )
-            sys.exit(1)
+            if exit_on_failure == "yes":
+                sys.exit(1)
     return return_code
 
 

--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 from functools import lru_cache
 from pathlib import Path
@@ -27,8 +28,13 @@ def check_formatter_installed(formatter_cmds: list[str]) -> bool:
         f.write(tmp_code)
         f.flush()
         tmp_file = Path(f.name)
-        format_code(formatter_cmds, tmp_file)
-    tmp_file.unlink(missing_ok=True)
+        try:
+            format_code(formatter_cmds, tmp_file)
+        except Exception:
+            print(
+                "⚠️ Failed to format code since formatter was not found in the environment. Please install it and try again."
+            )
+            sys.exit(1)
     return return_code
 
 

--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -12,13 +12,6 @@ from codeflash.code_utils.formatter import format_code
 from codeflash.code_utils.shell_utils import read_api_key_from_shell_config
 
 
-class FormatterNotFoundError(Exception):
-    """Exception raised when a formatter is not found."""
-
-    def __init__(self, formatter_cmd: str) -> None:
-        super().__init__(f"Formatter command not found: {formatter_cmd}")
-
-
 def check_formatter_installed(formatter_cmds: list[str]) -> bool:
     return_code = True
     if formatter_cmds[0] == "disabled":
@@ -32,7 +25,7 @@ def check_formatter_installed(formatter_cmds: list[str]) -> bool:
             format_code(formatter_cmds, tmp_file)
         except Exception:
             print(
-                "⚠️ Failed to format code since formatter was not found in the environment. Please install it and try again."
+                "⚠️ Codeflash requires a code formatter to be installed in your environment, but none was found. Please install a supported formatter, verify the formatter-cmds in your codeflash pyproject.toml config and try again."
             )
             sys.exit(1)
     return return_code

--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -12,7 +12,7 @@ from codeflash.code_utils.formatter import format_code
 from codeflash.code_utils.shell_utils import read_api_key_from_shell_config
 
 
-def check_formatter_installed(formatter_cmds: list[str], exit_on_failure: str = "yes") -> bool:
+def check_formatter_installed(formatter_cmds: list[str], exit_on_failure: bool = True) -> bool:  # noqa
     return_code = True
     if formatter_cmds[0] == "disabled":
         return return_code
@@ -27,7 +27,7 @@ def check_formatter_installed(formatter_cmds: list[str], exit_on_failure: str = 
             print(
                 "⚠️ Codeflash requires a code formatter to be installed in your environment, but none was found. Please install a supported formatter, verify the formatter-cmds in your codeflash pyproject.toml config and try again."
             )
-            if exit_on_failure == "yes":
+            if exit_on_failure:
                 sys.exit(1)
     return return_code
 

--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Optional
 
 from codeflash.cli_cmds.console import logger
+from codeflash.code_utils.formatter import format_code
 from codeflash.code_utils.shell_utils import read_api_key_from_shell_config
 
 
@@ -28,22 +29,8 @@ def check_formatter_installed(formatter_cmds: list[str]) -> bool:
         f.write(tmp_code)
         f.flush()
         tmp_file = Path(f.name)
-        file_token = "$file"  # noqa: S105
-        for command in set(formatter_cmds):
-            formatter_cmd_list = shlex.split(command, posix=os.name != "nt")
-            formatter_cmd_list = [tmp_file.as_posix() if chunk == file_token else chunk for chunk in formatter_cmd_list]
-            try:
-                result = subprocess.run(formatter_cmd_list, capture_output=True, check=False)
-            except (FileNotFoundError, NotADirectoryError):
-                return_code = False
-                break
-            if result.returncode:
-                return_code = False
-                break
+        format_code(formatter_cmds, tmp_file)
     tmp_file.unlink(missing_ok=True)
-    if not return_code:
-        msg = f"Error running formatter command: {command}"
-        raise FormatterNotFoundError(msg)
     return return_code
 
 

--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-import shlex
-import subprocess
 import tempfile
 from functools import lru_cache
 from pathlib import Path

--- a/codeflash/code_utils/formatter.py
+++ b/codeflash/code_utils/formatter.py
@@ -31,7 +31,7 @@ def format_code(formatter_cmds: list[str], path: Path) -> str:
                 console.rule(f"Formatted Successfully with: {formatter_name.replace('$file', path.name)}")
             else:
                 logger.error(f"Failed to format code with {' '.join(formatter_cmd_list)}")
-        except (FileNotFoundError, NotADirectoryError) as e:
+        except FileNotFoundError as e:
             from rich.panel import Panel
             from rich.text import Text
 

--- a/codeflash/code_utils/formatter.py
+++ b/codeflash/code_utils/formatter.py
@@ -31,7 +31,7 @@ def format_code(formatter_cmds: list[str], path: Path) -> str:
                 console.rule(f"Formatted Successfully with: {formatter_name.replace('$file', path.name)}")
             else:
                 logger.error(f"Failed to format code with {' '.join(formatter_cmd_list)}")
-        except FileNotFoundError as e:
+        except (FileNotFoundError, NotADirectoryError) as e:
             from rich.panel import Panel
             from rich.text import Text
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Use `format_code` to replace subprocess logic

- Remove manual formatter error handling

- Import `format_code` in env_utils module


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>env_utils.py</strong><dd><code>Use `format_code` in formatter check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/env_utils.py

<li>Added import of <code>format_code</code> function<br> <li> Replaced subprocess loop with <code>format_code</code> call<br> <li> Removed custom FormatterNotFoundError handling


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/254/files#diff-3fd62bf7fb084033c6aa51c61461b397543cc7bd9f86134e0c7640a15b00a8dc">+2/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>