### PR TITLE
don't count nested functions as it's own func

### DIFF
--- a/codeflash/discovery/functions_to_optimize.py
+++ b/codeflash/discovery/functions_to_optimize.py
@@ -94,8 +94,6 @@ class FunctionWithReturnStatement(ast.NodeVisitor):
             self.functions.append(
                 FunctionToOptimize(function_name=node.name, file_path=self.file_path, parents=self.ast_path[:])
             )
-        # Continue visiting the body of the function to find nested functions
-        self.generic_visit(node)
 
     def generic_visit(self, node: ast.AST) -> None:
         if isinstance(node, (FunctionDef, AsyncFunctionDef, ClassDef)):


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove nested function visits in FunctionDef

- Prevent nested functions from being counted

- Simplify visitor logic for FunctionDef nodes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>functions_to_optimize.py</strong><dd><code>Skip nested functions in visitor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/discovery/functions_to_optimize.py

<li>Deleted generic_visit call inside visit_FunctionDef<br> <li> Stops traversing into nested functions<br> <li> Keeps only top-level functions with returns


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/258/files#diff-adb17c14509d2bdc69ea39d82dfdde9c4c1c30277f9c8765b74ebb016b0c3cb3">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>