### PR TITLE
Rich error output during baseline establishment (CF-646)

### DIFF
--- a/codeflash/code_utils/code_utils.py
+++ b/codeflash/code_utils/code_utils.py
@@ -15,7 +15,7 @@ import tomlkit
 from codeflash.cli_cmds.console import logger
 from codeflash.code_utils.config_parser import find_pyproject_toml
 
-ImportErrorPattern = re.compile(r"^.*ModuleNotFoundError.*$", re.MULTILINE)
+ImportErrorPattern = re.compile(r"ModuleNotFoundError.*$", re.MULTILINE)
 
 
 @contextmanager

--- a/codeflash/code_utils/code_utils.py
+++ b/codeflash/code_utils/code_utils.py
@@ -15,6 +15,8 @@ import tomlkit
 from codeflash.cli_cmds.console import logger
 from codeflash.code_utils.config_parser import find_pyproject_toml
 
+ImportErrorPattern = re.compile(r"^.*ModuleNotFoundError.*$", re.MULTILINE)
+
 
 @contextmanager
 def custom_addopts() -> None:

--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 import concurrent.futures
 import os
-import re
 import subprocess
 import time
 import uuid
@@ -24,6 +23,7 @@ from codeflash.cli_cmds.console import code_print, console, logger, progress_bar
 from codeflash.code_utils import env_utils
 from codeflash.code_utils.code_replacer import replace_function_definitions_in_module
 from codeflash.code_utils.code_utils import (
+    ImportErrorPattern,
     cleanup_paths,
     file_name_from_test_module_name,
     get_run_tmp_file,
@@ -1196,7 +1196,7 @@ class FunctionOptimizer:
             if "ModuleNotFoundError" in run_result.stdout:
                 from rich.text import Text
 
-                match = re.search(r"^.*ModuleNotFoundError.*$", run_result.stdout, re.MULTILINE).group()
+                match = ImportErrorPattern.search(run_result.stdout).group()
                 panel = Panel(Text.from_markup(f"⚠️  {match} ", style="bold red"), expand=False)
                 console.print(panel)
         if testing_type in {TestingMode.BEHAVIOR, TestingMode.PERFORMANCE}:

--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import re
-
 import ast
 import concurrent.futures
 import os
+import re
 import subprocess
 import time
 import uuid
@@ -1194,13 +1193,11 @@ class FunctionOptimizer:
                 f"stdout: {run_result.stdout}\n"
                 f"stderr: {run_result.stderr}\n"
             )
-            if 'ModuleNotFoundError' in run_result.stdout:
+            if "ModuleNotFoundError" in run_result.stdout:
                 from rich.text import Text
-                match = re.search(r'^.*ModuleNotFoundError.*$', run_result.stdout, re.MULTILINE).group()
-                panel = Panel(
-                    Text.from_markup(f"⚠️  {match} ", style="bold red"),
-                    expand=False,
-                )
+
+                match = re.search(r"^.*ModuleNotFoundError.*$", run_result.stdout, re.MULTILINE).group()
+                panel = Panel(Text.from_markup(f"⚠️  {match} ", style="bold red"), expand=False)
                 console.print(panel)
         if testing_type in {TestingMode.BEHAVIOR, TestingMode.PERFORMANCE}:
             results, coverage_results = parse_test_results(

--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -1186,7 +1186,7 @@ class FunctionOptimizer:
             )
             return TestResults(), None
         if run_result.returncode != 0 and testing_type == TestingMode.BEHAVIOR:
-            logger.debug(
+            logger.info(
                 f"Nonzero return code {run_result.returncode} when running tests in "
                 f"{', '.join([str(f.instrumented_behavior_file_path) for f in test_files.test_files])}.\n"
                 f"stdout: {run_result.stdout}\n"

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -145,5 +145,5 @@ def test_sort():
             test_xml_file_path=result_file, test_files=test_files, test_config=config, run_result=process
         )
     match = ImportErrorPattern.search(process.stdout).group()
-    assert match=="E   ModuleNotFoundError: No module named 'torch'"
+    assert match=="ModuleNotFoundError: No module named 'torch'"
     result_file.unlink(missing_ok=True)

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -1,3 +1,5 @@
+import re
+
 import os
 import tempfile
 from pathlib import Path
@@ -95,4 +97,52 @@ def test_sort():
             test_xml_file_path=result_file, test_files=test_files, test_config=config, run_result=process
         )
     assert results[0].did_pass, "Test did not pass as expected"
+    result_file.unlink(missing_ok=True)
+
+    code = """import torch
+def sorter(arr):
+    print(torch.ones(1))
+    arr.sort()
+    return arr
+
+def test_sort():
+    arr = [5, 4, 3, 2, 1, 0]
+    output = sorter(arr)
+    assert output == [0, 1, 2, 3, 4, 5]
+    """
+    cur_dir_path = Path(__file__).resolve().parent
+    config = TestConfig(
+        tests_root=cur_dir_path,
+        project_root_path=cur_dir_path,
+        test_framework="pytest",
+        tests_project_rootdir=cur_dir_path.parent,
+    )
+
+    test_env = os.environ.copy()
+    test_env["CODEFLASH_TEST_ITERATION"] = "0"
+    test_env["CODEFLASH_TRACER_DISABLE"] = "1"
+    if "PYTHONPATH" not in test_env:
+        test_env["PYTHONPATH"] = str(config.project_root_path)
+    else:
+        test_env["PYTHONPATH"] += os.pathsep + str(config.project_root_path)
+
+    with tempfile.NamedTemporaryFile(prefix="test_xx", suffix=".py", dir=cur_dir_path) as fp:
+        test_files = TestFiles(
+            test_files=[TestFile(instrumented_behavior_file_path=Path(fp.name), test_type=TestType.EXISTING_UNIT_TEST)]
+        )
+        fp.write(code.encode("utf-8"))
+        fp.flush()
+        result_file, process, _, _ = run_behavioral_tests(
+            test_files,
+            test_framework=config.test_framework,
+            cwd=Path(config.project_root_path),
+            test_env=test_env,
+            pytest_timeout=1,
+            pytest_target_runtime_seconds=1,
+        )
+        results = parse_test_xml(
+            test_xml_file_path=result_file, test_files=test_files, test_config=config, run_result=process
+        )
+    match = re.search(r"^.*ModuleNotFoundError.*$", process.stdout, re.MULTILINE).group()
+    assert match=="E   ModuleNotFoundError: No module named 'torch'"
     result_file.unlink(missing_ok=True)

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from pathlib import Path
 
+from codeflash.code_utils.code_utils import ImportErrorPattern
 from codeflash.models.models import TestFile, TestFiles, TestType
 from codeflash.verification.parse_test_output import parse_test_xml
 from codeflash.verification.test_runner import run_behavioral_tests
@@ -143,6 +144,6 @@ def test_sort():
         results = parse_test_xml(
             test_xml_file_path=result_file, test_files=test_files, test_config=config, run_result=process
         )
-    match = re.search(r"^.*ModuleNotFoundError.*$", process.stdout, re.MULTILINE).group()
+    match = ImportErrorPattern.search(process.stdout).group()
     assert match=="E   ModuleNotFoundError: No module named 'torch'"
     result_file.unlink(missing_ok=True)


### PR DESCRIPTION
### **User description**
It could help the user with cancelling the current run if certain modules are not found during a run.

this PR will only show the first import error as the code would stop executing the moment the first import fails. capturing all import errors will require a different way of test instrumentation. 


___

### **PR Type**
Enhancement


___

### **Description**
- Improve error reporting on missing modules

- Detect ModuleNotFoundError in test outputs

- Show errors using Rich panel

- Add import for regex parsing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function_optimizer.py</strong><dd><code>Detect and display ModuleNotFoundError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/function_optimizer.py

<li>Added import of <code>re</code> for error parsing<br> <li> Check stdout for 'ModuleNotFoundError'<br> <li> Use Rich <code>Text</code> and <code>Panel</code> for styled output<br> <li> Console.print error panel on failure


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/265/files#diff-c31e19bcea34bd30ef3c0be56164bea577174363ba3320c4999bf1926ea8ce79">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>