### PR TITLE
Instrumented tests do not inherit the existing decorators of the uninstrumented tests (CF-660)

### DIFF
--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -657,6 +657,7 @@ class FunctionOptimizer:
         get_run_tmp_file(Path("test_return_values_0.sqlite")).unlink(missing_ok=True)
 
     def instrument_existing_tests(self, function_to_all_tests: dict[str, list[FunctionCalledInTest]]) -> set[Path]:
+        # TODO : ensure all existing decorators are present after instrumentation
         existing_test_files_count = 0
         replay_test_files_count = 0
         concolic_coverage_test_files_count = 0


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Add TODO for decorator inheritance in instrumentation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function_optimizer.py</strong><dd><code>TODO for ensuring decorator inheritance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/function_optimizer.py

- Inserted TODO comment to preserve existing decorators


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/280/files#diff-c31e19bcea34bd30ef3c0be56164bea577174363ba3320c4999bf1926ea8ce79">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>