### PR TITLE
Save replay tests to test dir

### DIFF
--- a/codeflash/cli_cmds/cli.py
+++ b/codeflash/cli_cmds/cli.py
@@ -140,9 +140,6 @@ def process_pyproject_config(args: Namespace) -> Namespace:
         assert Path(args.benchmarks_root).is_dir(), (
             f"--benchmarks-root {args.benchmarks_root} must be a valid directory"
         )
-        assert Path(args.benchmarks_root).resolve().is_relative_to(Path(args.tests_root).resolve()), (
-            f"--benchmarks-root {args.benchmarks_root} must be a subdirectory of --tests-root {args.tests_root}"
-        )
         if env_utils.get_pr_number() is not None:
             import git
 

--- a/codeflash/optimization/optimizer.py
+++ b/codeflash/optimization/optimizer.py
@@ -129,7 +129,7 @@ class Optimizer:
                         trace_file.unlink()
 
                     self.replay_tests_dir = Path(
-                        tempfile.mkdtemp(prefix="codeflash_replay_tests_", dir=self.args.benchmarks_root)
+                        tempfile.mkdtemp(prefix="codeflash_replay_tests_", dir=self.args.tests_root)
                     )
                     trace_benchmarks_pytest(
                         self.args.benchmarks_root, self.args.tests_root, self.args.project_root, trace_file

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -16,6 +16,7 @@ tests-root = "tests"
 test-framework = "pytest"
 formatter-cmds = ["black $file"]
 # optional configuration
+benchmarks-root = "tests/benchmarks" # Required when running with --benchmark
 ignore-paths = ["my_module/build/"]
 pytest-cmd = "pytest"
 disable-imports-sorting = false
@@ -29,6 +30,7 @@ Required Options:
 - `test-framework`: The test framework you use for your project. Codeflash supports `pytest` and `unittest`.
 
 Optional Configuration:
+- `benchmarks-root`: The directory where your benchmarks are located. Codeflash will use this directory to discover existing benchmarks. Note that this option is required when running with `--benchmark`.
 - `ignore-paths`: A list of paths withing the `module-root` to ignore when optimizing code. Codeflash will not optimize code in these paths. Useful for ignoring build directories or other generated code. You can also leave this empty if not needed.
 - `pytest-cmd`: The command to run your tests. Defaults to `pytest`. You can specify extra commandline arguments here for pytest.
 - `formatter-cmds`: The command line to run your code formatter or linter. Defaults to `["black $file"]`. In the command line `$file` refers to the current file being optimized. The assumption with using tools here is that they overwrite the same file and returns a zero exit code. You can also specify multiple tools here that run in a chain as a toml array. You can also disable code formatting by setting this to `["disabled"]`.

--- a/docs/docs/optimizing-with-codeflash/benchmarking.md
+++ b/docs/docs/optimizing-with-codeflash/benchmarking.md
@@ -13,7 +13,7 @@ Codeflash will then calculate the impact (if any) of any optimization on the per
 
 1. **Create a benchmarks root** 
 
-    Create a directory for benchmarks. This directory must be a sub directory of your tests directory.
+    Create a directory for benchmarks. 
 
    In your pyproject.toml, add the path to the 'benchmarks-root' section.
     ```yaml

--- a/docs/docs/optimizing-with-codeflash/benchmarking.md
+++ b/docs/docs/optimizing-with-codeflash/benchmarking.md
@@ -3,7 +3,7 @@ sidebar_position: 5
 ---
 # Using Benchmarks
 
-Codeflash is able the determine the impact of an optimization on predefined benchmarks, when used in benchmark mode.
+Codeflash is able to determine the impact of an optimization on predefined benchmarks, when used in benchmark mode.
 
 Benchmark mode is an easy way for users to define workflows that are performance-critical and need to be optimized.
 For example, if a user has an important function that requires minimal latency, the user can define a benchmark for that function.
@@ -13,7 +13,7 @@ Codeflash will then calculate the impact (if any) of any optimization on the per
 
 1. **Create a benchmarks root** 
 
-    Create a directory for benchmarks. 
+    Create a directory for benchmarks if it does not already exist. 
 
    In your pyproject.toml, add the path to the 'benchmarks-root' section.
     ```yaml


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Relax `--benchmarks-root` subdirectory requirement

- Create replay tests under `tests_root` directory


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Remove benchmarks_root subdir assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cli.py

<li>Removed assertion enforcing <code>benchmarks_root</code> under <code>tests_root</code><br> <li> No longer checks subdirectory relationship between roots


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/317/files#diff-21f18b94ebed099d24b96475865ff5c2ac245020f73a6b8de0c3790c7a46b2ad">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>optimizer.py</strong><dd><code>Save replay tests under tests_root</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/optimizer.py

<li>Changed <code>tempfile.mkdtemp</code> directory to use <code>tests_root</code><br> <li> Ensures replay tests saved in tests directory, not benchmarks


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/317/files#diff-d242b27fa098f222741a48a7daa8e421433b4c5e19dd38512404cd000df144a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>