### PR TITLE
save codeflash config to pyproject even if formatter isn't installed CF-673

### DIFF
--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -22,13 +22,12 @@ def check_formatter_installed(formatter_cmds: list[str], exit_on_failure: bool =
         f.flush()
         tmp_file = Path(f.name)
         try:
-            format_code(formatter_cmds, tmp_file, print_status=False)
+            format_code(formatter_cmds, tmp_file, print_status=False, exit_on_failure=exit_on_failure)
         except Exception:
             exit_with_message(
                 "⚠️ Codeflash requires a code formatter to be installed in your environment, but none was found. Please install a supported formatter, verify the formatter-cmds in your codeflash pyproject.toml config and try again.",
                 error_on_exit=True,
             )
-
     return return_code
 
 

--- a/codeflash/code_utils/formatter.py
+++ b/codeflash/code_utils/formatter.py
@@ -43,6 +43,7 @@ def apply_formatter_cmds(
     path: Path,
     test_dir_str: Optional[str],
     print_status: bool,  # noqa
+    exit_on_failure: bool = True,  # noqa
 ) -> tuple[Path, str]:
     # TODO: Only allow a particular whitelist of formatters here to prevent arbitrary code execution
     formatter_name = cmds[0].lower()
@@ -84,8 +85,8 @@ def apply_formatter_cmds(
                 expand=False,
             )
             console.print(panel)
-
-            raise e from None
+            if exit_on_failure:
+                raise e from None
 
     return file_path, file_path.read_text(encoding="utf8")
 
@@ -106,6 +107,7 @@ def format_code(
     optimized_function: str = "",
     check_diff: bool = False,  # noqa
     print_status: bool = True,  # noqa
+    exit_on_failure: bool = True,  # noqa
 ) -> str:
     with tempfile.TemporaryDirectory() as test_dir_str:
         if isinstance(path, str):
@@ -138,7 +140,9 @@ def format_code(
                 )
                 return original_code
         # TODO : We can avoid formatting the whole file again and only formatting the optimized code standalone and replace in formatted file above.
-        _, formatted_code = apply_formatter_cmds(formatter_cmds, path, test_dir_str=None, print_status=print_status)
+        _, formatted_code = apply_formatter_cmds(
+            formatter_cmds, path, test_dir_str=None, print_status=print_status, exit_on_failure=exit_on_failure
+        )
         logger.debug(f"Formatted {path} with commands: {formatter_cmds}")
         return formatted_code
 

--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced by poetry-dynamic-versioning during `poetry build`.
-__version__ = "0.14.4.post2.dev0+8ce25197"
-__version_tuple__ = (0, 14, 4, "post2", "dev0", "8ce25197")
+__version__ = "0.14.4"
+__version_tuple__ = (0, 14, 4)

--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,3 +1,3 @@
 # These version placeholders will be replaced by poetry-dynamic-versioning during `poetry build`.
-__version__ = "0.14.4"
-__version_tuple__ = (0, 14, 4)
+__version__ = "0.14.4.post2.dev0+8ce25197"
+__version_tuple__ = (0, 14, 4, "post2", "dev0", "8ce25197")


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
Propagate exit_on_failure flag in formatting utilities
Conditionally suppress formatter errors
Update apply_formatter_cmds and format_code signatures
Bump version to 0.14.4.post2.dev0+8ce25197


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>env_utils.py</strong><dd><code>Propagate exit_on_failure to format_code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/env_utils.py

<li>Pass <code>exit_on_failure</code> to <code>format_code</code> call<br> <li> Remove redundant error handling fallback


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/351/files#diff-3fd62bf7fb084033c6aa51c61461b397543cc7bd9f86134e0c7640a15b00a8dc">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>formatter.py</strong><dd><code>Add exit_on_failure handling in formatter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/formatter.py

<li>Add <code>exit_on_failure</code> parameter to functions<br> <li> Conditionally raise on missing formatter error<br> <li> Forward <code>exit_on_failure</code> through <code>format_code</code> and <code>apply_formatter_cmds</code>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/351/files#diff-ead54b6ab4522d27ae1bc0af93885ab05a8f49ea3c96308972c17deaa97515d2">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.py</strong><dd><code>Update project version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/version.py

<li>Bump <code>__version__</code> to post2.dev0 build metadata<br> <li> Expand <code>__version_tuple__</code> to include metadata parts


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/351/files#diff-82d999c8c95d5a642725636040b7629283f1d1bd87b51a8b05c787712d56f673">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>