### PR TITLE
[Chore] Error message on missing API key for forks (CF-675)

### DIFF
--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from codeflash.cli_cmds.console import logger
 from codeflash.code_utils.code_utils import exit_with_message
@@ -34,11 +35,19 @@ def check_formatter_installed(formatter_cmds: list[str], exit_on_failure: bool =
 @lru_cache(maxsize=1)
 def get_codeflash_api_key() -> str:
     api_key = os.environ.get("CODEFLASH_API_KEY") or read_api_key_from_shell_config()
+    api_secret_docs_message = "For more information, refer to the documentation at [https://docs.codeflash.ai/getting-started/codeflash-github-actions#add-your-api-key-to-your-repository-secrets]."  # noqa
     if not api_key:
         msg = (
             "I didn't find a Codeflash API key in your environment.\nYou can generate one at "
-            "https://app.codeflash.ai/app/apikeys ,\nthen set it as a CODEFLASH_API_KEY environment variable."
+            "https://app.codeflash.ai/app/apikeys ,\nthen set it as a CODEFLASH_API_KEY environment variable.\n"
+            f"{api_secret_docs_message}"
         )
+        if is_repo_a_fork():
+            msg = (
+                "Codeflash API key not detected in your environment. It appears you're running Codeflash from a GitHub fork.\n"
+                "For external contributors, please ensure you've added your own API key to your fork's repository secrets and set it as the CODEFLASH_API_KEY environment variable.\n"
+                f"{api_secret_docs_message}"
+            )
         raise OSError(msg)
     if not api_key.startswith("cf-"):
         msg = (
@@ -83,3 +92,20 @@ def ensure_pr_number() -> bool:
 @lru_cache(maxsize=1)
 def is_end_to_end() -> bool:
     return bool(os.environ.get("CODEFLASH_END_TO_END"))
+
+
+@lru_cache(maxsize=1)
+def is_repo_a_fork() -> bool:
+    event = get_cached_gh_event_data()
+    if event is None:
+        return False
+    return bool(event["repository"]["fork"])
+
+
+@lru_cache(maxsize=1)
+def get_cached_gh_event_data() -> dict[str, Any] | None:
+    event_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        return None
+    with Path(event_path).open() as f:
+        return json.load(f)  # type: ignore  # noqa

--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -48,6 +48,7 @@ def get_codeflash_api_key() -> str:
                 "For external contributors, please ensure you've added your own API key to your fork's repository secrets and set it as the CODEFLASH_API_KEY environment variable.\n"
                 f"{api_secret_docs_message}"
             )
+            exit_with_message(msg)
         raise OSError(msg)
     if not api_key.startswith("cf-"):
         msg = (


### PR DESCRIPTION
### **User description**
![2025-06-24_03-20](https://github.com/user-attachments/assets/b864f6da-28b7-4141-8a29-10e2351cc221)


___

### **PR Type**
Enhancement


___

### **Description**
- Enhance API key error messaging for forks

- Add fork detection via GITHUB_EVENT_PATH

- Include docs link in error message

- Import json and adjust type hints


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>env_utils.py</strong><dd><code>Fork detection and improved API key errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/env_utils.py

<li>Imported json for parsing GitHub event data<br> <li> Added get_cached_gh_event_data to read GITHUB_EVENT_PATH<br> <li> Implemented is_repo_a_fork to detect forked repositories<br> <li> Enhanced get_codeflash_api_key error messages for forks<br> <li> Included documentation link in API key errors


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/371/files#diff-3fd62bf7fb084033c6aa51c61461b397543cc7bd9f86134e0c7640a15b00a8dc">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>