### PR TITLE
minor modification for checking replay tests passing

### DIFF
--- a/codeflash/result/critic.py
+++ b/codeflash/result/critic.py
@@ -56,8 +56,8 @@ def quantity_of_tests_critic(candidate_result: OptimizedCandidateResult) -> bool
 
     if pass_count >= MIN_TESTCASE_PASSED_THRESHOLD:
         return True
-    # If only one test passed, check if it's a REPLAY_TEST
-    return bool(pass_count == 1 and report[TestType.REPLAY_TEST]["passed"] == 1)
+    # If one or more tests passed, check if least one of them was a successful REPLAY_TEST
+    return bool(pass_count >= 1 and report[TestType.REPLAY_TEST]["passed"] >= 1)
 
 
 def coverage_critic(original_code_coverage: CoverageData | None, test_framework: str) -> bool:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Broaden replay test pass condition

- Allow any pass with one REPLAY_TEST

- Remove strict one-pass requirement


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>critic.py</strong><dd><code>Relax REPLAY_TEST pass threshold logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/result/critic.py

<li>Simplified <code>quantity_of_tests_critic</code> logic<br> <li> Changed replay test condition to at-least-one<br> <li> Updated comment describing replay logic


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/443/files#diff-d864e393fe88c465537539fa8fcfadb965293d0f00de5ae17e030c5db90038f0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>