### PR TITLE
Add no-pr argument to CF LSP

### DIFF
--- a/codeflash/lsp/server.py
+++ b/codeflash/lsp/server.py
@@ -52,5 +52,6 @@ class CodeflashLanguageServer(LanguageServer):
 
         args = parse_args()
         args.config_file = config_file
+        args.no_pr = True  # LSP server should not create PRs
         args = process_pyproject_config(args)
         self.optimizer = Optimizer(args)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Disable PR creation in LSP server initialization


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Add no_pr flag to LSP server init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/lsp/server.py

- Set `args.no_pr = True` before optimizer initialization


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/449/files#diff-57c5fb2bd3572c756fcab246eff6537406cd98f91d5089da8b6a61d44f16f909">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>