### PR TITLE
disable concolic testing in LSP mode

### DIFF
--- a/codeflash/api/aiservice.py
+++ b/codeflash/api/aiservice.py
@@ -10,7 +10,7 @@ import requests
 from pydantic.json import pydantic_encoder
 
 from codeflash.cli_cmds.console import console, logger
-from codeflash.code_utils.env_utils import get_codeflash_api_key
+from codeflash.code_utils.env_utils import get_codeflash_api_key, is_LSP_enabled
 from codeflash.code_utils.git_utils import get_last_commit_author_if_pr_exists, get_repo_owner_and_name
 from codeflash.models.models import OptimizedCandidate
 from codeflash.telemetry.posthog_cf import ph
@@ -182,6 +182,7 @@ class AiServiceClient:
             "python_version": platform.python_version(),
             "experiment_metadata": experiment_metadata,
             "codeflash_version": codeflash_version,
+            "lsp_mode": is_LSP_enabled(),
         }
 
         logger.info("Generating optimized candidates…")

--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -7,7 +7,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 
-from codeflash.cli_cmds.console import logger
+from codeflash.cli_cmds.console import console, logger
 from codeflash.code_utils.code_utils import exit_with_message
 from codeflash.code_utils.formatter import format_code
 from codeflash.code_utils.shell_utils import read_api_key_from_shell_config
@@ -110,3 +110,8 @@ def get_cached_gh_event_data() -> dict[str, Any] | None:
         return None
     with Path(event_path).open() as f:
         return json.load(f)  # type: ignore  # noqa
+
+
+@lru_cache(maxsize=1)
+def is_LSP_enabled() -> bool:
+    return console.quiet

--- a/codeflash/verification/concolic_testing.py
+++ b/codeflash/verification/concolic_testing.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from codeflash.cli_cmds.console import console, logger
 from codeflash.code_utils.compat import SAFE_SYS_EXECUTABLE
 from codeflash.code_utils.concolic_utils import clean_concolic_tests
+from codeflash.code_utils.env_utils import is_LSP_enabled
 from codeflash.code_utils.static_analysis import has_typed_parameters
 from codeflash.discovery.discover_unit_tests import discover_unit_tests
 from codeflash.telemetry.posthog_cf import ph
@@ -28,6 +29,11 @@ def generate_concolic_tests(
     start_time = time.perf_counter()
     function_to_concolic_tests = {}
     concolic_test_suite_code = ""
+
+    if is_LSP_enabled():
+        logger.debug("Skipping concolic test generation in LSP mode")
+        return function_to_concolic_tests, concolic_test_suite_code
+
     if (
         test_cfg.concolic_test_root_dir
         and isinstance(function_to_optimize_ast, (ast.FunctionDef, ast.AsyncFunctionDef))


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add is_LSP_enabled utility for LSP detection

- Skip concolic test generation in LSP mode

- Include lsp_mode flag in API requests

- Adjust imports for console usage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aiservice.py</strong><dd><code>Add LSP flag to API optimizer payload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/api/aiservice.py

<li>Imported <code>is_LSP_enabled</code> from env_utils<br> <li> Added <code>lsp_mode</code> flag to optimizer payload


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/450/files#diff-4c389c6ea409e24e72ff69a5b3af3005f22e3fce55d6361b48f1fa2cba658b31">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>env_utils.py</strong><dd><code>Introduce is_LSP_enabled utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/env_utils.py

<li>Imported console for quiet mode detection<br> <li> Added cached <code>is_LSP_enabled</code> function


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/450/files#diff-3fd62bf7fb084033c6aa51c61461b397543cc7bd9f86134e0c7640a15b00a8dc">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>concolic_testing.py</strong><dd><code>Skip concolic tests under LSP mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/verification/concolic_testing.py

<li>Imported <code>is_LSP_enabled</code><br> <li> Skip concolic tests in LSP mode<br> <li> Early return empty results when LSP enabled


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/450/files#diff-3c2cc2b76a60e927f54b737e154204cddc1dd1a1ba3b915accb6625ede77c386">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>