### PR TITLE
Just clean all leftover instrumented tests

### DIFF
--- a/codeflash/optimization/optimizer.py
+++ b/codeflash/optimization/optimizer.py
@@ -332,7 +332,7 @@ class Optimizer:
         """Search for all paths within the test_root that match the following patterns.
 
         - 'test.*__perf_test_{0,1}.py'
-        - 'test_.*__unit_{0,1}.py'
+        - 'test_.*__unit_test_{0,1}.py'
         - 'test_.*__perfinstrumented.py'
         - 'test_.*__perfonlyinstrumented.py'
         Returns a list of matching file paths.
@@ -340,10 +340,12 @@ class Optimizer:
         import re
 
         pattern = re.compile(
-            r"^(test.*__perf_test_?\.py|test_.*__unit_?\.py|test_.*__perfinstrumented\.py|test_.*__perfonlyinstrumented\.py)$"
+            r"(?:test.*__perf_test_\d?\.py|test_.*__unit_test_\d?\.py|test_.*__perfinstrumented\.py|test_.*__perfonlyinstrumented\.py)$"
         )
 
-        return [file for file in test_root.rglob("test_*.py") if pattern.match(file.name)]
+        return [
+            file_path for file_path in test_root.rglob("*") if file_path.is_file() and pattern.match(file_path.name)
+        ]
 
     def cleanup_temporary_paths(self) -> None:
         if self.current_function_optimizer:


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add static method to find instrumented test files

- Invoke cleanup before optimization run

- Refactor `cleanup_temporary_paths` logic

- Improve regex for test file matching


___

### **Changes diagram**

```mermaid
flowchart LR
  run["Optimizer.run()"] -- "invoke cleanup" --> find["find_leftover_instrumented_test_files"]
  find -- "matching files" --> clean1["cleanup_paths(files)"]
  run -- "finally" --> temp_cleanup["cleanup_temporary_paths()"]
  temp_cleanup -- "cleanup dirs" --> clean2["cleanup_paths(dirs)"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>optimizer.py</strong><dd><code>Refactor and extend cleanup logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/optimizer.py

<li>Imported <code>cleanup_paths</code> from <code>code_utils</code><br> <li> Added <code>find_leftover_instrumented_test_files</code> static method<br> <li> Called cleanup early in <code>run()</code><br> <li> Refactored <code>cleanup_temporary_paths</code> implementation


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/454/files#diff-d242b27fa098f222741a48a7daa8e421433b4c5e19dd38512404cd000df144a0">+22/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>