### PR TITLE
[Enhancement] Better shell regex for matching api key export

### DIFF
--- a/codeflash/code_utils/shell_utils.py
+++ b/codeflash/code_utils/shell_utils.py
@@ -15,7 +15,7 @@ if os.name == "nt":  # Windows
     SHELL_RC_EXPORT_PATTERN = re.compile(r"^set CODEFLASH_API_KEY=(cf-.*)$", re.MULTILINE)
     SHELL_RC_EXPORT_PREFIX = "set CODEFLASH_API_KEY="
 else:
-    SHELL_RC_EXPORT_PATTERN = re.compile(r'^export CODEFLASH_API_KEY="?(cf-[^\s"]+)"?$', re.MULTILINE)
+    SHELL_RC_EXPORT_PATTERN = re.compile(r'^(?!#)export CODEFLASH_API_KEY=[\'"]?(cf-[^\s"]+)[\'"]$', re.MULTILINE)
     SHELL_RC_EXPORT_PREFIX = "export CODEFLASH_API_KEY="
 
 

--- a/tests/test_shell_utils.py
+++ b/tests/test_shell_utils.py
@@ -54,6 +54,16 @@ class TestReadApiKeyFromShellConfig(unittest.TestCase):
             ) as mock_file:
                 self.assertEqual(read_api_key_from_shell_config(), self.api_key)
                 mock_file.assert_called_once_with(self.test_rc_path, encoding="utf8")
+            with patch(
+                "builtins.open", mock_open(read_data=f'export CODEFLASH_API_KEY=\'{self.api_key}\'\n')
+            ) as mock_file:
+                self.assertEqual(read_api_key_from_shell_config(), self.api_key)
+                mock_file.assert_called_once_with(self.test_rc_path, encoding="utf8")
+            with patch(
+                "builtins.open", mock_open(read_data=f'#export CODEFLASH_API_KEY=\'{self.api_key}\'\n')
+            ) as mock_file:
+                self.assertEqual(read_api_key_from_shell_config(), None)
+                mock_file.assert_called_once_with(self.test_rc_path, encoding="utf8")
 
     @patch("codeflash.code_utils.shell_utils.get_shell_rc_path")
     def test_no_api_key(self, mock_get_shell_rc_path):


### PR DESCRIPTION
### **User description**
- support single quotes, double quotes
- ignore lines starting with #


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Update export regex to ignore commented lines

- Support single and double quotes in export

- Add test for single-quoted API key

- Add test for commented-out export returns None


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shell_utils.py</strong><dd><code>Improve shell export regex</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/shell_utils.py

<li>Modified SHELL_RC_EXPORT_PATTERN regex<br> <li> Added negative lookahead to skip commented lines<br> <li> Adjusted quote handling to accept single quotes


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/462/files#diff-8d76cb604358d4f7ee14584102bfeda361788f405310193ef88801f4eeaa881d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_shell_utils.py</strong><dd><code>Add tests for shell regex enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_shell_utils.py

<li>Added test for single-quoted API key<br> <li> Added test for ignored commented export<br> <li> Ensured file open encoding remains utf8


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/462/files#diff-a4cd614642ab34cc96782d51292042a514001cdaa407dd7d839d54e923c4bc10">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>