### PR TITLE
Create dedicated server entry point to prevent crashes

### DIFF
--- a/codeflash/lsp/beta.py
+++ b/codeflash/lsp/beta.py
@@ -292,10 +292,3 @@ def perform_function_optimization(  # noqa: PLR0911
         "extra": f"Speedup: {speedup:.2f}x faster",
         "optimization": optimized_source,
     }
-
-
-if __name__ == "__main__":
-    from codeflash.cli_cmds.console import console
-
-    console.quiet = True
-    server.start_io()

--- a/codeflash/lsp/server.py
+++ b/codeflash/lsp/server.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from lsprotocol.types import INITIALIZE
+from lsprotocol.types import INITIALIZE, MessageType, LogMessageParams
 from pygls import uris
 from pygls.protocol import LanguageServerProtocol, lsp_method
 from pygls.server import LanguageServer
@@ -55,3 +55,24 @@ class CodeflashLanguageServer(LanguageServer):
         args.no_pr = True  # LSP server should not create PRs
         args = process_pyproject_config(args)
         self.optimizer = Optimizer(args)
+
+    def show_message_log(self, message: str, message_type: str) -> None:
+        """Send a log message to the client's output channel.
+        
+        Args:
+            message: The message to log
+            message_type: String type - "Info", "Warning", "Error", or "Log"
+        """
+        # Convert string message type to LSP MessageType enum
+        type_mapping = {
+            "Info": MessageType.Info,
+            "Warning": MessageType.Warning, 
+            "Error": MessageType.Error,
+            "Log": MessageType.Log
+        }
+        
+        lsp_message_type = type_mapping.get(message_type, MessageType.Info)
+        
+        # Send log message to client (appears in output channel)
+        log_params = LogMessageParams(type=lsp_message_type, message=message)
+        self.lsp.notify("window/logMessage", log_params)

--- a/codeflash/lsp/server_entry.py
+++ b/codeflash/lsp/server_entry.py
@@ -1,42 +1,48 @@
-"""
-This script is the dedicated entry point for the Codeflash Language Server.
+"""This script is the dedicated entry point for the Codeflash Language Server.
 It initializes the server and redirects its logs to stderr so that the
 VS Code client can display them in the output channel.
 
 This script is run by the VS Code extension and is not intended to be
 executed directly by users.
 """
+
 import logging
 import sys
-import os
+
 from codeflash.lsp.beta import server
+
 
 # Configure logging to stderr for VS Code output channel
 def setup_logging():
     # Clear any existing handlers to prevent conflicts
     root_logger = logging.getLogger()
     root_logger.handlers.clear()
-    
+
     # Set up stderr handler for VS Code output channel with [LSP-Server] prefix
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(logging.Formatter("[LSP-Server] %(asctime)s [%(levelname)s]: %(message)s"))
-    
+
     # Configure root logger
     root_logger.addHandler(handler)
     root_logger.setLevel(logging.INFO)
-    
+
     # Also configure the pygls logger specifically
-    pygls_logger = logging.getLogger('pygls')
+    pygls_logger = logging.getLogger("pygls")
     pygls_logger.setLevel(logging.INFO)
-    
+
     return root_logger
 
-# Set up logging
-log = setup_logging()
 
-# Silence the console module to prevent stdout pollution
-from codeflash.cli_cmds.console import console
-console.quiet = True
+if __name__ == "__main__":
+    # Set up logging
+    log = setup_logging()
+    log.info("Starting Codeflash Language Server...")
 
-log.info("Starting Codeflash Language Server...")
-server.start_io()
+    # Silence the console module to prevent stdout pollution
+    from codeflash.cli_cmds.console import console
+
+    console.quiet = True
+    # console.enable()
+
+    # Start the language server
+    server.start_io()

--- a/codeflash/lsp/server_entry.py
+++ b/codeflash/lsp/server_entry.py
@@ -1,0 +1,42 @@
+"""
+This script is the dedicated entry point for the Codeflash Language Server.
+It initializes the server and redirects its logs to stderr so that the
+VS Code client can display them in the output channel.
+
+This script is run by the VS Code extension and is not intended to be
+executed directly by users.
+"""
+import logging
+import sys
+import os
+from codeflash.lsp.beta import server
+
+# Configure logging to stderr for VS Code output channel
+def setup_logging():
+    # Clear any existing handlers to prevent conflicts
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    
+    # Set up stderr handler for VS Code output channel with [LSP-Server] prefix
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("[LSP-Server] %(asctime)s [%(levelname)s]: %(message)s"))
+    
+    # Configure root logger
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.INFO)
+    
+    # Also configure the pygls logger specifically
+    pygls_logger = logging.getLogger('pygls')
+    pygls_logger.setLevel(logging.INFO)
+    
+    return root_logger
+
+# Set up logging
+log = setup_logging()
+
+# Silence the console module to prevent stdout pollution
+from codeflash.cli_cmds.console import console
+console.quiet = True
+
+log.info("Starting Codeflash Language Server...")
+server.start_io()


### PR DESCRIPTION
 fix(lsp): 
- > Isolates the LSP server from the main CLI argument parser by creating a new, dedicated entry point.
    Previously, the VS Code extension launched the LSP server using the main application's module (`codeflash.lsp.beta`). This caused the server to crash on startup because it was incorrectly processing the main CLI's argument parser, which expected a subcommand to start like init.
     1.  Creating a new `codeflash.lsp.server_entry` module.
     2.  This new entry point starts the `pygls` server directly, bypassing the main CLI's argument parser entirely.
     3.  Configuring the server's root logger to direct all logs to `stderr`, allowing the VS Code client to capture and display them in the output channel without corrupting the `stdout`
      communication stream.
  
   These change basically ensures the LSP server starts reliably and that all its logs are correctly forwarded to the client for a better debugging experience.



### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add show_message_log to LSP server

- Create dedicated server_entry script

- Configure stderr logging for VS Code

- Silence console output and start server


___

### **Changes diagram**

```mermaid
flowchart LR
  A["setup_logging()"] --> B["Configure stderr logging"]
  B --> C["Start LSP server via server.start_io()"]
  C --> D["show_message_log"]
  D -- "window/logMessage" --> E["VS Code output channel"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Implement show_message_log in server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/lsp/server.py

<li>Import MessageType and LogMessageParams<br> <li> Add show_message_log method for client logging


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/464/files#diff-57c5fb2bd3572c756fcab246eff6537406cd98f91d5089da8b6a61d44f16f909">+22/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_entry.py</strong><dd><code>Add server_entry script and logging setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/lsp/server_entry.py

<li>New entry point script for LSP server<br> <li> Setup logging to stderr with custom formatter<br> <li> Silence console output and start server


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/464/files#diff-e1ae0b94c3ece52ddd08c128b553401f2d9c81d4cdfe4e2beb90f60e050eae43">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>