### PR TITLE
remove benchmark-roots prompt in cmd init

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -228,19 +228,6 @@ def collect_setup_info() -> SetupInfo:
     custom_dir_option = "enter a custom directory…"
     module_subdir_options = [*valid_module_subdirs, curdir_option, custom_dir_option]
 
-    info_panel = Panel(
-        Text(
-            "📁 Let's identify your Python module directory.\n\n"
-            "This is usually the top-level directory containing all your Python source code.\n"
-            "We've automatically detected some directories for you.",
-            style="cyan",
-        ),
-        title="🔍 Module Discovery",
-        border_style="bright_blue",
-    )
-    console.print(info_panel)
-    console.print()
-
     questions = [
         inquirer.List(
             "module_root",
@@ -936,7 +923,6 @@ def configure_pyproject_toml(setup_info: SetupInfo) -> None:
     codeflash_section["module-root"] = setup_info.module_root
     codeflash_section["tests-root"] = setup_info.tests_root
     codeflash_section["test-framework"] = setup_info.test_framework
-    codeflash_section["benchmarks-root"] = setup_info.benchmarks_root if setup_info.benchmarks_root else ""
     codeflash_section["ignore-paths"] = setup_info.ignore_paths
     codeflash_section["disable-telemetry"] = not enable_telemetry
     if setup_info.git_remote not in ["", "origin"]:

--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -228,6 +228,18 @@ def collect_setup_info() -> SetupInfo:
     custom_dir_option = "enter a custom directory…"
     module_subdir_options = [*valid_module_subdirs, curdir_option, custom_dir_option]
 
+    info_panel = Panel(
+        Text(
+            "📁 Let's identify your Python module directory.\n\n"
+            "This is usually the top-level directory containing all your Python source code.\n",
+            style="cyan",
+        ),
+        title="🔍 Module Discovery",
+        border_style="bright_blue",
+    )
+    console.print(info_panel)
+    console.print()
+
     questions = [
         inquirer.List(
             "module_root",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed module discovery info panel

- Simplified prompt asking module root

- Dropped benchmarks-root in pyproject config


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cmd_init.py</strong><dd><code>Clean up init prompts and config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cmd_init.py

<li>Deleted info_panel displaying module discovery prompts<br> <li> Removed extra console print newline<br> <li> Eliminated codeflash_section['benchmarks-root'] assignment


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/507/files#diff-c15be1c100e57b623163c38b4995067f137d3ad0cf5c3e8cebeaa2f32ef86fc8">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>