### PR TITLE
[FIX] duplicate code context error in our github workflow

### DIFF
--- a/codeflash/api/cfapi.py
+++ b/codeflash/api/cfapi.py
@@ -240,6 +240,9 @@ def add_code_context_hash(code_context_hash: str) -> None:
         return
     try:
         owner, repo = get_repo_owner_and_name()
+        # don't add the context hash for codeflash repo
+        if f"{owner}/{repo}" != "codeflash-ai/codeflash":
+            return
         pr_number = get_pr_number()
     except git.exc.InvalidGitRepositoryError:
         return

--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -335,9 +335,7 @@ class FunctionOptimizer:
             test_functions_to_remove=test_functions_to_remove,
             concolic_test_str=concolic_test_str,
         )
-
-        # Add function to code context hash if in gh actions
-
+        # don't add the context hash for codeflash repo
         add_code_context_hash(code_context.hashing_code_context_hash)
 
         if self.args.override_fixtures:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Skip context hash on non-codeflash repos

- Update optimizer context hash comment


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cfapi.py</strong><dd><code>Add skip guard for code context hashing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/api/cfapi.py

<li>Added condition to skip context hash for non-codeflash repo<br> <li> Placed guard after retrieving repo owner/name


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/552/files#diff-4db91bebdd89f96b3b270c5169a5b35a98b0be8806758e0e8e055d7aacf6d4a5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function_optimizer.py</strong><dd><code>Refine context hash comment in optimizer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/function_optimizer.py

<li>Replaced GH actions comment with repo-skipping note<br> <li> Removed outdated context hash comment


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/552/files#diff-c31e19bcea34bd30ef3c0be56164bea577174363ba3320c4999bf1926ea8ce79">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>