### PR TITLE
[FIX] Get fork property in github event correctly

### DIFF
--- a/codeflash/code_utils/env_utils.py
+++ b/codeflash/code_utils/env_utils.py
@@ -111,7 +111,7 @@ def get_cached_gh_event_data() -> dict[str, Any]:
 
 def is_repo_a_fork() -> bool:
     event = get_cached_gh_event_data()
-    return bool(event.get("repository", {}).get("fork", False))
+    return bool(event.get("pull_request", {}).get("head", {}).get("repo", {}).get("fork", False))
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
## How I tested it:

created a fork repo and raised a pull request in the base repo, wrote a github action to save the events.json file as an artifact

<img width="1352" height="210" alt="image" src="https://github.com/user-attachments/assets/fd2c8ee2-1a68-4beb-a4ee-ec84d7f2c53f" />

for some odd reason pull_request.fork is giving false (it was working before maybe they changed it), the pull_request.head.repo.fork though is returning true, so we can use that.

<img width="633" height="158" alt="image" src="https://github.com/user-attachments/assets/5b110a51-f98c-4b24-aa02-0028e6e05560" />
