### PR TITLE
3.13 test

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:

--- a/tests/test_instrument_tests.py
+++ b/tests/test_instrument_tests.py
@@ -129,11 +129,7 @@ def codeflash_wrap(wrapped, test_module_name, test_class_name, test_name, functi
     codeflash_test_index = codeflash_wrap.index[test_id]
     invocation_id = f'{{line_id}}_{{codeflash_test_index}}'
     """
-    if sys.version_info < (3, 12):
-        expected += """test_stdout_tag = f"{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}"
-    """
-    else:
-        expected += """test_stdout_tag = f'{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}'
+    expected += """test_stdout_tag = f'{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}'
     """
     expected += """print(f'!$######{{test_stdout_tag}}######$!')
     exception = None
@@ -189,9 +185,9 @@ class TestPigLatin(unittest.TestCase):
         )
         os.chdir(original_cwd)
     assert success
-    assert new_test == expected.format(
+    assert new_test.replace('"', "'") == expected.format(
         module_path=Path(f.name).name, tmp_dir_path=get_run_tmp_file(Path("test_return_values"))
-    )
+    ).replace('"', "'")
 
 
 def test_perfinjector_only_replay_test() -> None:
@@ -233,11 +229,7 @@ def codeflash_wrap(wrapped, test_module_name, test_class_name, test_name, functi
     codeflash_test_index = codeflash_wrap.index[test_id]
     invocation_id = f'{{line_id}}_{{codeflash_test_index}}'
     """
-    if sys.version_info < (3, 12):
-        expected += """test_stdout_tag = f"{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}"
-    """
-    else:
-        expected += """test_stdout_tag = f'{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}'
+    expected += """test_stdout_tag = f'{{test_module_name}}:{{(test_class_name + '.' if test_class_name else '')}}{{test_name}}:{{function_name}}:{{loop_index}}:{{invocation_id}}'
     """
     expected += """print(f'!$######{{test_stdout_tag}}######$!')
     exception = None
@@ -289,9 +281,9 @@ def test_prepare_image_for_yolo():
         )
         os.chdir(original_cwd)
     assert success
-    assert new_test == expected.format(
+    assert new_test.replace('"', "'") == expected.format(
         module_path=Path(f.name).name, tmp_dir_path=get_run_tmp_file(Path("test_return_values"))
-    )
+    ).replace('"', "'")
 
 
 def test_perfinjector_bubble_sort_results() -> None:


### PR DESCRIPTION
### **PR Type**
Tests, Enhancement


___

### **Description**
- Normalize test f-string quoting conditions

- Update assertions replacing double quotes

- Add Python 3.13 to CI testing matrix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["Pull Request"] -->|"Modify test assertions"| Tests["tests/test_instrument_tests.py"]
  PR -->|"Update CI matrix"| CI[".github/workflows/unit-tests.yaml"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_instrument_tests.py</strong><dd><code>Unify test string formatting and comparisons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_instrument_tests.py

<ul><li>Removed version-specific f-string quoting conditional<br> <li> Unified expected <code>test_stdout_tag</code> f-string syntax<br> <li> Updated assertions to replace double quotes with single</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/585/files#diff-7edc17a8f718b9ee52dc20091cb34041920cfc0d513cb8dcd25b6e9ce03a3dec">+6/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>unit-tests.yaml</strong><dd><code>Add Python 3.13 to CI matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/unit-tests.yaml

<ul><li>Added Python 3.13 to CI testing matrix<br> <li> Extended CI job strategy matrix</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/585/files#diff-6e608e02c595d53ab6b70822a2bf19abcfc6ddcc976c2f536ad5bfca20f0443f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

