### PR TITLE
Benchmark Fixture fixes

### DIFF
--- a/codeflash-benchmark/codeflash_benchmark/__init__.py
+++ b/codeflash-benchmark/codeflash_benchmark/__init__.py
@@ -1,0 +1,3 @@
+"""CodeFlash Benchmark - Pytest benchmarking plugin for codeflash.ai."""
+
+__version__ = "0.1.0"

--- a/codeflash-benchmark/codeflash_benchmark/plugin.py
+++ b/codeflash-benchmark/codeflash_benchmark/plugin.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from codeflash.benchmarking.plugin.plugin import codeflash_benchmark_plugin
+
+PYTEST_BENCHMARK_INSTALLED = importlib.util.find_spec("pytest_benchmark") is not None
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the benchmark marker and disable conflicting plugins."""
+    config.addinivalue_line("markers", "benchmark: mark test as a benchmark that should be run with codeflash tracing")
+
+    if config.getoption("--codeflash-trace") and PYTEST_BENCHMARK_INSTALLED:
+        config.option.benchmark_disable = True
+        config.pluginmanager.set_blocked("pytest_benchmark")
+        config.pluginmanager.set_blocked("pytest-benchmark")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--codeflash-trace", action="store_true", default=False, help="Enable CodeFlash tracing for benchmarks"
+    )
+
+
+
+@pytest.fixture
+def benchmark(request: pytest.FixtureRequest) -> object:
+    """Benchmark fixture that works with or without pytest-benchmark installed."""
+    config = request.config
+
+    # If --codeflash-trace is enabled, use our implementation
+    if config.getoption("--codeflash-trace"):
+        return codeflash_benchmark_plugin.Benchmark(request)
+
+    # If pytest-benchmark is installed and --codeflash-trace is not enabled,
+    # return the normal pytest-benchmark fixture
+    if PYTEST_BENCHMARK_INSTALLED:
+        from pytest_benchmark.fixture import BenchmarkFixture as BSF  # noqa: N814
+
+        bs = getattr(config, "_benchmarksession", None)
+        if bs and bs.skip:
+            pytest.skip("Benchmarks are skipped (--benchmark-skip was used).")
+
+        node = request.node
+        marker = node.get_closest_marker("benchmark")
+        options = dict(marker.kwargs) if marker else {}
+
+        if bs:
+            return BSF(
+                node,
+                add_stats=bs.benchmarks.append,
+                logger=bs.logger,
+                warner=request.node.warn,
+                disabled=bs.disabled,
+                **dict(bs.options, **options),
+            )
+        return lambda func, *args, **kwargs: func(*args, **kwargs)
+
+    return lambda func, *args, **kwargs: func(*args, **kwargs)

--- a/codeflash-benchmark/pyproject.toml
+++ b/codeflash-benchmark/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "codeflash-benchmark"
+version = "0.1.0"
+description = "Pytest benchmarking plugin for codeflash.ai - automatic code performance optimization"
+authors = [{ name = "CodeFlash Inc.", email = "contact@codeflash.ai" }]
+requires-python = ">=3.9"
+readme = "README.md"
+license = {text = "BSL-1.1"}
+keywords = [
+    "codeflash",
+    "benchmark",
+    "pytest",
+    "performance",
+    "testing",
+]
+dependencies = [
+    "pytest>=7.0.0,!=8.3.4",
+]
+
+[project.urls]
+Homepage = "https://codeflash.ai"
+Repository = "https://github.com/codeflash-ai/codeflash-benchmark"
+
+[project.entry-points.pytest11]
+codeflash-benchmark = "codeflash_benchmark.plugin"
+
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["codeflash_benchmark"]

--- a/codeflash/benchmarking/plugin/plugin.py
+++ b/codeflash/benchmarking/plugin/plugin.py
@@ -16,7 +16,7 @@ from codeflash.code_utils.code_utils import module_name_from_file_path
 if TYPE_CHECKING:
     from codeflash.models.models import BenchmarkKey
 
-IS_PYTEST_BENCHMARK_INSTALLED = importlib.util.find_spec("pytest_benchmark") is not None
+PYTEST_BENCHMARK_INSTALLED = importlib.util.find_spec("pytest_benchmark") is not None
 
 
 class CodeFlashBenchmarkPlugin:
@@ -251,8 +251,12 @@ class CodeFlashBenchmarkPlugin:
 
         def _run_benchmark(self, func, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
             """Actual benchmark implementation."""
+            node_path = getattr(self.request.node, "path", None) or getattr(self.request.node, "fspath", None)
+            if node_path is None:
+                raise RuntimeError("Unable to determine test file path from pytest node")
+
             benchmark_module_path = module_name_from_file_path(
-                Path(str(self.request.node.fspath)), Path(codeflash_benchmark_plugin.project_root), traverse_up=True
+                Path(str(node_path)), Path(codeflash_benchmark_plugin.project_root), traverse_up=True
             )
 
             benchmark_function_name = self.request.node.name
@@ -284,24 +288,17 @@ class CodeFlashBenchmarkPlugin:
 codeflash_benchmark_plugin = CodeFlashBenchmarkPlugin()
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    """Register the benchmark marker and disable conflicting plugins."""
-    config.addinivalue_line("markers", "benchmark: mark test as a benchmark that should be run with codeflash tracing")
+# def pytest_configure(config: pytest.Config) -> None:
+#     """Register the benchmark marker and disable conflicting plugins."""
+#     config.addinivalue_line("markers", "benchmark: mark test as a benchmark that should be run with codeflash tracing")
 
-    if config.getoption("--codeflash-trace") and IS_PYTEST_BENCHMARK_INSTALLED:
-        config.option.benchmark_disable = True
-        config.pluginmanager.set_blocked("pytest_benchmark")
-        config.pluginmanager.set_blocked("pytest-benchmark")
-
-
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--codeflash-trace", action="store_true", default=False, help="Enable CodeFlash tracing for benchmarks"
-    )
+#     if config.getoption("--codeflash-trace") and PYTEST_BENCHMARK_INSTALLED:
+#         config.option.benchmark_disable = True
+#         config.pluginmanager.set_blocked("pytest_benchmark")
+#         config.pluginmanager.set_blocked("pytest-benchmark")
 
 
-@pytest.fixture
-def benchmark(request: pytest.FixtureRequest) -> object:
-    if not request.config.getoption("--codeflash-trace"):
-        return lambda func, *args, **kwargs: func(*args, **kwargs)
-    return codeflash_benchmark_plugin.Benchmark(request)
+# def pytest_addoption(parser: pytest.Parser) -> None:
+#     parser.addoption(
+#         "--codeflash-trace", action="store_true", default=False, help="Enable CodeFlash tracing for benchmarks"
+#     )

--- a/codeflash/benchmarking/pytest_new_process_trace_benchmarks.py
+++ b/codeflash/benchmarking/pytest_new_process_trace_benchmarks.py
@@ -7,10 +7,13 @@ from codeflash.benchmarking.plugin.plugin import codeflash_benchmark_plugin
 benchmarks_root = sys.argv[1]
 tests_root = sys.argv[2]
 trace_file = sys.argv[3]
-# current working directory
 project_root = Path.cwd()
+
 if __name__ == "__main__":
     import pytest
+
+    orig_recursion_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(orig_recursion_limit * 2)
 
     try:
         codeflash_benchmark_plugin.setup(trace_file, project_root)
@@ -32,9 +35,12 @@ if __name__ == "__main__":
                 "addopts=",
             ],
             plugins=[codeflash_benchmark_plugin],
-        )  # Errors will be printed to stdout, not stderr
-
+        )
     except Exception as e:
         print(f"Failed to collect tests: {e!s}", file=sys.stderr)
         exitcode = -1
+    finally:
+        # Restore the original recursion limit
+        sys.setrecursionlimit(orig_recursion_limit)
+
     sys.exit(exitcode)

--- a/codeflash/benchmarking/replay_test.py
+++ b/codeflash/benchmarking/replay_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sqlite3
 import textwrap
 from pathlib import Path
@@ -13,6 +14,8 @@ from codeflash.verification.verification_utils import get_test_file_path
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+benchmark_context_cleaner = re.compile(r"[^a-zA-Z0-9_]+")
 
 
 def get_next_arg_and_return(
@@ -44,6 +47,16 @@ def get_next_arg_and_return(
 
 def get_function_alias(module: str, function_name: str) -> str:
     return "_".join(module.split(".")) + "_" + function_name
+
+
+def get_unique_test_name(module: str, function_name: str, benchmark_name: str, class_name: str | None = None) -> str:
+    clean_benchmark = benchmark_context_cleaner.sub("_", benchmark_name).strip("_")
+
+    base_alias = get_function_alias(module, function_name)
+    if class_name:
+        class_alias = get_function_alias(module, class_name)
+        return f"{class_alias}_{function_name}_{clean_benchmark}"
+    return f"{base_alias}_{clean_benchmark}"
 
 
 def create_trace_replay_test_code(
@@ -209,7 +222,8 @@ trace_file_path = r"{trace_file}"
         formatted_test_body = textwrap.indent(test_body, "        " if test_framework == "unittest" else "    ")
 
         test_template += "    " if test_framework == "unittest" else ""
-        test_template += f"def test_{alias}({self}):\n{formatted_test_body}\n"
+        unique_test_name = get_unique_test_name(module_name, function_name, benchmark_function_name, class_name)
+        test_template += f"def test_{unique_test_name}({self}):\n{formatted_test_body}\n"
 
     return imports + "\n" + metadata + "\n" + test_template
 

--- a/codeflash/benchmarking/trace_benchmarks.py
+++ b/codeflash/benchmarking/trace_benchmarks.py
@@ -12,6 +12,7 @@ from codeflash.code_utils.compat import SAFE_SYS_EXECUTABLE
 def trace_benchmarks_pytest(
     benchmarks_root: Path, tests_root: Path, project_root: Path, trace_file: Path, timeout: int = 300
 ) -> None:
+    logger.info("Tracing benchmarks with codeflash-benchmark")
     benchmark_env = os.environ.copy()
     if "PYTHONPATH" not in benchmark_env:
         benchmark_env["PYTHONPATH"] = str(project_root)
@@ -32,6 +33,8 @@ def trace_benchmarks_pytest(
         env=benchmark_env,
         timeout=timeout,
     )
+    logger.info(f"ran with args: {result.args}")
+    logger.info(f"Pytest output: {result.stderr}")
     if result.returncode != 0:
         if "ERROR collecting" in result.stdout:
             # Pattern matches "===== ERRORS =====" (any number of =) and captures everything after

--- a/codeflash/models/models.py
+++ b/codeflash/models/models.py
@@ -515,6 +515,7 @@ class TestResults(BaseModel):
                 benchmark_replay_test_dir.resolve()
                 / f"test_{benchmark_key.module_path.replace('.', '_')}__replay_test_",
                 project_root,
+                traverse_up=True,
             )
         for test_result in self.test_results:
             if test_result.test_type == TestType.REPLAY_TEST:

--- a/codeflash/optimization/optimizer.py
+++ b/codeflash/optimization/optimizer.py
@@ -74,6 +74,7 @@ class Optimizer:
             for file in file_to_funcs_to_optimize:
                 with file.open("r", encoding="utf8") as f:
                     file_path_to_source_code[file] = f.read()
+            console.print(f"Instrumented {len(file_to_funcs_to_optimize)} files for benchmarking…")
             try:
                 instrument_codeflash_trace_decorator(file_to_funcs_to_optimize)
                 trace_file = Path(self.args.benchmarks_root) / "benchmarks.trace"
@@ -83,6 +84,7 @@ class Optimizer:
                 self.replay_tests_dir = Path(
                     tempfile.mkdtemp(prefix="codeflash_replay_tests_", dir=self.args.benchmarks_root)
                 )
+                logger.info(f"Tracing benchmarks to {trace_file} in {self.replay_tests_dir}")
                 trace_benchmarks_pytest(
                     self.args.benchmarks_root, self.args.tests_root, self.args.project_root, trace_file
                 )  # Run all tests that use pytest-benchmark

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "line_profiler>=4.2.0",
     "platformdirs>=4.3.7",
     "pygls>=1.3.1",
+    "codeflash-benchmark",
 ]
 
 [project.urls]
@@ -52,6 +53,7 @@ codeflash = "codeflash.main:main"
 
 [dependency-groups]
 dev = [
+    "codeflash-benchmark",
     "ipython>=8.12.0",
     "mypy>=1.13",
     "ruff>=0.7.0",
@@ -262,6 +264,12 @@ skip-magic-trailing-comma = true
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
 
+[tool.uv]
+workspace = { members = ["codeflash-benchmark"] }
+
+[tool.uv.sources]
+codeflash-benchmark = { workspace = true }
+
 [tool.uv-dynamic-versioning]
 enable = true
 style = "pep440"
@@ -300,5 +308,3 @@ markers = [
 requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
 
-[project.entry-points.pytest11]
-codeflash = "codeflash.benchmarking.plugin.plugin"

--- a/tests/test_pickle_patcher.py
+++ b/tests/test_pickle_patcher.py
@@ -364,7 +364,7 @@ def test_run_and_parse_picklepatch() -> None:
         test_env["CODEFLASH_TEST_ITERATION"] = "0"
         test_env["CODEFLASH_LOOP_INDEX"] = "1"
         test_type = TestType.REPLAY_TEST
-        replay_test_function = "test_code_to_optimize_bubble_sort_picklepatch_test_unused_socket_bubble_sort_with_unused_socket"
+        replay_test_function = "test_code_to_optimize_bubble_sort_picklepatch_test_unused_socket_bubble_sort_with_unused_socket_test_socket_picklepatch"
         func_optimizer = opt.create_function_optimizer(func)
         func_optimizer.test_files = TestFiles(
             test_files=[
@@ -388,7 +388,7 @@ def test_run_and_parse_picklepatch() -> None:
         )
         assert len(test_results_unused_socket) == 1
         assert test_results_unused_socket.test_results[0].id.test_module_path == "code_to_optimize.tests.pytest.benchmarks_socket_test.codeflash_replay_tests.test_code_to_optimize_tests_pytest_benchmarks_socket_test_test_socket__replay_test_0"
-        assert test_results_unused_socket.test_results[0].id.test_function_name == "test_code_to_optimize_bubble_sort_picklepatch_test_unused_socket_bubble_sort_with_unused_socket"
+        assert test_results_unused_socket.test_results[0].id.test_function_name == "test_code_to_optimize_bubble_sort_picklepatch_test_unused_socket_bubble_sort_with_unused_socket_test_socket_picklepatch"
         assert test_results_unused_socket.test_results[0].did_pass == True
 
         # Replace with optimized candidate
@@ -439,7 +439,7 @@ def bubble_sort_with_unused_socket(data_container):
         test_type = TestType.REPLAY_TEST
         func = FunctionToOptimize(function_name="bubble_sort_with_used_socket", parents=[],
                                   file_path=Path(fto_used_socket_path))
-        replay_test_function = "test_code_to_optimize_bubble_sort_picklepatch_test_used_socket_bubble_sort_with_used_socket"
+        replay_test_function = "test_code_to_optimize_bubble_sort_picklepatch_test_used_socket_bubble_sort_with_used_socket_test_used_socket_picklepatch"
         func_optimizer = opt.create_function_optimizer(func)
         func_optimizer.test_files = TestFiles(
             test_files=[
@@ -467,7 +467,7 @@ def bubble_sort_with_unused_socket(data_container):
         assert test_results_used_socket.test_results[
                    0].id.test_module_path == "code_to_optimize.tests.pytest.benchmarks_socket_test.codeflash_replay_tests.test_code_to_optimize_tests_pytest_benchmarks_socket_test_test_socket__replay_test_0"
         assert test_results_used_socket.test_results[
-                   0].id.test_function_name == "test_code_to_optimize_bubble_sort_picklepatch_test_used_socket_bubble_sort_with_used_socket"
+                   0].id.test_function_name == "test_code_to_optimize_bubble_sort_picklepatch_test_used_socket_bubble_sort_with_used_socket_test_used_socket_picklepatch"
         assert test_results_used_socket.test_results[0].did_pass is False
         print("test results used socket")
         print(test_results_used_socket)
@@ -498,7 +498,7 @@ def bubble_sort_with_used_socket(data_container):
         assert test_results_used_socket.test_results[
                    0].id.test_module_path == "code_to_optimize.tests.pytest.benchmarks_socket_test.codeflash_replay_tests.test_code_to_optimize_tests_pytest_benchmarks_socket_test_test_socket__replay_test_0"
         assert test_results_used_socket.test_results[
-                   0].id.test_function_name == "test_code_to_optimize_bubble_sort_picklepatch_test_used_socket_bubble_sort_with_used_socket"
+                   0].id.test_function_name == "test_code_to_optimize_bubble_sort_picklepatch_test_used_socket_bubble_sort_with_used_socket_test_used_socket_picklepatch"
         assert test_results_used_socket.test_results[0].did_pass is False
 
         # Even though tests threw the same error, we reject this as the behavior of the unpickleable object could not be determined.

--- a/tests/test_trace_benchmarks.py
+++ b/tests/test_trace_benchmarks.py
@@ -33,7 +33,7 @@ def test_trace_benchmarks() -> None:
         function_calls = cursor.fetchall()
 
         # Assert the length of function calls
-        assert len(function_calls) == 7, f"Expected 7 function calls, but got {len(function_calls)}"
+        assert len(function_calls) == 8, f"Expected 8 function calls, but got {len(function_calls)}"
 
         bubble_sort_path = (project_root / "bubble_sort_codeflash_trace.py").as_posix()
         process_and_bubble_sort_path = (project_root / "process_and_bubble_sort_codeflash_trace.py").as_posix()
@@ -95,13 +95,13 @@ from codeflash.picklepatch.pickle_patcher import PicklePatcher as pickle
 functions = ['sort_class', 'sort_static', 'sorter']
 trace_file_path = r"{output_file.as_posix()}"
 
-def test_code_to_optimize_bubble_sort_codeflash_trace_sorter():
+def test_code_to_optimize_bubble_sort_codeflash_trace_sorter_test_sort():
     for args_pkl, kwargs_pkl in get_next_arg_and_return(trace_file=trace_file_path, benchmark_function_name="test_sort", function_name="sorter", file_path=r"{bubble_sort_path}", num_to_get=100):
         args = pickle.loads(args_pkl)
         kwargs = pickle.loads(kwargs_pkl)
         ret = code_to_optimize_bubble_sort_codeflash_trace_sorter(*args, **kwargs)
 
-def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter_sorter():
+def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter_sorter_test_class_sort():
     for args_pkl, kwargs_pkl in get_next_arg_and_return(trace_file=trace_file_path, benchmark_function_name="test_class_sort", function_name="sorter", file_path=r"{bubble_sort_path}", class_name="Sorter", num_to_get=100):
         args = pickle.loads(args_pkl)
         kwargs = pickle.loads(kwargs_pkl)
@@ -113,7 +113,7 @@ def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter_sorter():
         else:
             ret = code_to_optimize_bubble_sort_codeflash_trace_Sorter.sorter(*args, **kwargs)
 
-def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter_sort_class():
+def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter_sort_class_test_class_sort2():
     for args_pkl, kwargs_pkl in get_next_arg_and_return(trace_file=trace_file_path, benchmark_function_name="test_class_sort2", function_name="sort_class", file_path=r"{bubble_sort_path}", class_name="Sorter", num_to_get=100):
         args = pickle.loads(args_pkl)
         kwargs = pickle.loads(kwargs_pkl)
@@ -121,13 +121,13 @@ def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter_sort_class():
             raise ValueError("No arguments provided for the method.")
         ret = code_to_optimize_bubble_sort_codeflash_trace_Sorter.sort_class(*args[1:], **kwargs)
 
-def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter_sort_static():
+def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter_sort_static_test_class_sort3():
     for args_pkl, kwargs_pkl in get_next_arg_and_return(trace_file=trace_file_path, benchmark_function_name="test_class_sort3", function_name="sort_static", file_path=r"{bubble_sort_path}", class_name="Sorter", num_to_get=100):
         args = pickle.loads(args_pkl)
         kwargs = pickle.loads(kwargs_pkl)
         ret = code_to_optimize_bubble_sort_codeflash_trace_Sorter.sort_static(*args, **kwargs)
 
-def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter___init__():
+def test_code_to_optimize_bubble_sort_codeflash_trace_Sorter___init___test_class_sort4():
     for args_pkl, kwargs_pkl in get_next_arg_and_return(trace_file=trace_file_path, benchmark_function_name="test_class_sort4", function_name="__init__", file_path=r"{bubble_sort_path}", class_name="Sorter", num_to_get=100):
         args = pickle.loads(args_pkl)
         kwargs = pickle.loads(kwargs_pkl)
@@ -156,13 +156,13 @@ from codeflash.picklepatch.pickle_patcher import PicklePatcher as pickle
 functions = ['compute_and_sort', 'sorter']
 trace_file_path = r"{output_file}"
 
-def test_code_to_optimize_process_and_bubble_sort_codeflash_trace_compute_and_sort():
+def test_code_to_optimize_process_and_bubble_sort_codeflash_trace_compute_and_sort_test_compute_and_sort():
     for args_pkl, kwargs_pkl in get_next_arg_and_return(trace_file=trace_file_path, benchmark_function_name="test_compute_and_sort", function_name="compute_and_sort", file_path=r"{process_and_bubble_sort_path}", num_to_get=100):
         args = pickle.loads(args_pkl)
         kwargs = pickle.loads(kwargs_pkl)
         ret = code_to_optimize_process_and_bubble_sort_codeflash_trace_compute_and_sort(*args, **kwargs)
 
-def test_code_to_optimize_bubble_sort_codeflash_trace_sorter():
+def test_code_to_optimize_bubble_sort_codeflash_trace_sorter_test_no_func():
     for args_pkl, kwargs_pkl in get_next_arg_and_return(trace_file=trace_file_path, benchmark_function_name="test_no_func", function_name="sorter", file_path=r"{bubble_sort_path}", num_to_get=100):
         args = pickle.loads(args_pkl)
         kwargs = pickle.loads(kwargs_pkl)

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,12 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 
+[manifest]
+members = [
+    "codeflash",
+    "codeflash-benchmark",
+]
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -210,6 +216,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "codeflash-benchmark" },
     { name = "coverage" },
     { name = "crosshair-tool" },
     { name = "dill" },
@@ -239,6 +246,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "codeflash-benchmark" },
     { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "ipython", version = "9.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -268,6 +276,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
+    { name = "codeflash-benchmark", editable = "codeflash-benchmark" },
     { name = "coverage", specifier = ">=7.6.4" },
     { name = "crosshair-tool", specifier = ">=0.0.78" },
     { name = "dill", specifier = ">=0.3.8" },
@@ -297,6 +306,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codeflash-benchmark", editable = "codeflash-benchmark" },
     { name = "ipython", specifier = ">=8.12.0" },
     { name = "lxml-stubs", specifier = ">=0.5.1" },
     { name = "mypy", specifier = ">=1.13" },
@@ -319,6 +329,17 @@ dev = [
     { name = "types-unidiff", specifier = ">=0.7.0.20240505,<0.8" },
     { name = "uv", specifier = ">=0.6.2" },
 ]
+
+[[package]]
+name = "codeflash-benchmark"
+version = "0.1.0"
+source = { editable = "codeflash-benchmark" }
+dependencies = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytest", specifier = ">=7.0.0,!=8.3.4" }]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
### **User description**
Update plugin.py


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Rename pytest benchmark installed constant

- Extend benchmark fixture for compatibility

- Fallback identity fixture if neither installed

- Add minimal sleep in test discovery


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pytest fixture request"]
  B{"--codeflash-trace?"}
  D{"pytest-benchmark installed?"}
  A --> B
  B -- "yes" --> C["CodeFlash Benchmark"]
  B -- "no" --> D
  D -- "yes" --> E["pytest-benchmark Fixture"]
  D -- "no" --> F["Identity lambda"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin.py</strong><dd><code>Support pytest-benchmark and rename constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/benchmarking/plugin/plugin.py

<ul><li>Renamed <code>IS_PYTEST_BENCHMARK_INSTALLED</code> to <code>PYTEST_BENCHMARK_INSTALLED</code><br> <li> Updated <code>pytest_configure</code> to disable pytest-benchmark correctly<br> <li> Extended <code>benchmark</code> fixture:<br>   - uses CodeFlash when traced<br>   - uses <br>pytest-benchmark if installed<br>   - falls back to identity lambda<br> <li> Added fixture docstring</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/586/files#diff-17c54b346432c9145edb49dd0c82b133160918353c32fbb02a0b0f4a84fc3d16">+33/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>discover_unit_tests.py</strong><dd><code>Added sleep delay in test discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/discovery/discover_unit_tests.py

<ul><li>Imported <code>sleep</code> from <code>time</code><br> <li> Inserted <code>sleep(0.0001)</code> after <code>jedi.Project</code> init</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/586/files#diff-d4a934ababd112412f396a9574cfd3d3bec4a7cff98dd6b29d1505bccf24987a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

