### PR TITLE
[FIX] Reset valid_optimization for each experiment

### DIFF
--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -1028,6 +1028,7 @@ class FunctionOptimizer:
             if candidates is None:
                 continue
 
+            self.valid_optimizations = []  # reset for each experiment
             best_optimization = self.determine_best_candidate(
                 candidates=candidates,
                 code_context=code_context,


### PR DESCRIPTION
### **User description**
in experiment mode EXP0 valid_optimizations are not cleared before starting the EXP1 optimization


___

### **PR Type**
Bug fix


___

### **Description**
- Reset `valid_optimizations` each experiment iteration

- Prevent stale optimizations carryover across experiments


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function_optimizer.py</strong><dd><code>Reset valid_optimizations per experiment iteration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/function_optimizer.py

<ul><li>Added reset of <code>valid_optimizations</code> inside loop<br> <li> Clears stale optimizations before determining best candidate</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/607/files#diff-c31e19bcea34bd30ef3c0be56164bea577174363ba3320c4999bf1926ea8ce79">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

