### PR TITLE
Non-Blocking Async refinement calls for better queing CF-666

### DIFF
--- a/codeflash/optimization/optimizer.py
+++ b/codeflash/optimization/optimizer.py
@@ -333,6 +333,7 @@ class Optimizer:
                             continue
                     finally:
                         if function_optimizer is not None:
+                            function_optimizer.executor.shutdown(wait=True)
                             function_optimizer.cleanup_generated_files()
 
             ph("cli-optimize-run-finished", {"optimizations_found": optimizations_found})


### PR DESCRIPTION
### **User description**
I'm interleaving refinement generation with the candidate evaluation for better cpu utilization and non blocking calls. awaiting in the end when there is nothing else to do. This should save some time in the candidate evaluation loop.


___

### **PR Type**
Enhancement


___

### **Description**
- Asynchronously submit refinement tasks in loop

- Change refine_optimizations to return Future

- Increase executor pool size to 3 workers

- Remove blocking synchronous refinement logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["determine_best_candidate start"]
  B["ThreadPoolExecutor with 3 workers"]
  C["Submit line profiler tasks"]
  D["Submit refine_optimizations futures"]
  E["Wait for refinement futures"]
  F["Extend candidates with refinements"]
  A --> B
  B --> C
  C --> D
  D --> E
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function_optimizer.py</strong><dd><code>Enable async refinement task handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/function_optimizer.py

<ul><li>Increased ThreadPoolExecutor workers from 2 to 3<br> <li> Collected refinement tasks as futures asynchronously<br> <li> Removed blocking refinement logic at loop end<br> <li> Updated refine_optimizations to return Future</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/609/files#diff-c31e19bcea34bd30ef3c0be56164bea577174363ba3320c4999bf1926ea8ce79">+25/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

