### PR TITLE
Pydantic benchmark plugin fix

### DIFF
--- a/codeflash-benchmark/codeflash_benchmark/plugin.py
+++ b/codeflash-benchmark/codeflash_benchmark/plugin.py
@@ -8,13 +8,35 @@ from codeflash.benchmarking.plugin.plugin import codeflash_benchmark_plugin
 
 PYTEST_BENCHMARK_INSTALLED = importlib.util.find_spec("pytest_benchmark") is not None
 
+benchmark_options = [
+    ("--benchmark-columns", "store", None, "Benchmark columns"),
+    ("--benchmark-group-by", "store", None, "Benchmark group by"),
+    ("--benchmark-name", "store", None, "Benchmark name pattern"),
+    ("--benchmark-sort", "store", None, "Benchmark sort column"),
+    ("--benchmark-json", "store", None, "Benchmark JSON output file"),
+    ("--benchmark-save", "store", None, "Benchmark save name"),
+    ("--benchmark-warmup", "store", None, "Benchmark warmup"),
+    ("--benchmark-warmup-iterations", "store", None, "Benchmark warmup iterations"),
+    ("--benchmark-min-time", "store", None, "Benchmark minimum time"),
+    ("--benchmark-max-time", "store", None, "Benchmark maximum time"),
+    ("--benchmark-min-rounds", "store", None, "Benchmark minimum rounds"),
+    ("--benchmark-timer", "store", None, "Benchmark timer"),
+    ("--benchmark-calibration-precision", "store", None, "Benchmark calibration precision"),
+    ("--benchmark-disable", "store_true", False, "Disable benchmarks"),
+    ("--benchmark-skip", "store_true", False, "Skip benchmarks"),
+    ("--benchmark-only", "store_true", False, "Only run benchmarks"),
+    ("--benchmark-verbose", "store_true", False, "Verbose benchmark output"),
+    ("--benchmark-histogram", "store", None, "Benchmark histogram"),
+    ("--benchmark-compare", "store", None, "Benchmark compare"),
+    ("--benchmark-compare-fail", "store", None, "Benchmark compare fail threshold"),
+]
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Register the benchmark marker and disable conflicting plugins."""
     config.addinivalue_line("markers", "benchmark: mark test as a benchmark that should be run with codeflash tracing")
 
     if config.getoption("--codeflash-trace") and PYTEST_BENCHMARK_INSTALLED:
-        config.option.benchmark_disable = True
         config.pluginmanager.set_blocked("pytest_benchmark")
         config.pluginmanager.set_blocked("pytest-benchmark")
 
@@ -23,6 +45,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--codeflash-trace", action="store_true", default=False, help="Enable CodeFlash tracing for benchmarks"
     )
+    # These options are ignored when --codeflash-trace is used
+    for option, action, default, help_text in benchmark_options:
+        help_suffix = (
+            " (ignored when --codeflash-trace is used)" if "disable" not in option and "skip" not in option else ""
+        )
+        parser.addoption(option, action=action, default=default, help=help_text + help_suffix)
 
 
 @pytest.fixture

--- a/codeflash-benchmark/pyproject.toml
+++ b/codeflash-benchmark/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codeflash-benchmark"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pytest benchmarking plugin for codeflash.ai - automatic code performance optimization"
 authors = [{ name = "CodeFlash Inc.", email = "contact@codeflash.ai" }]
 requires-python = ">=3.9"
@@ -25,7 +25,7 @@ Repository = "https://github.com/codeflash-ai/codeflash-benchmark"
 codeflash-benchmark = "codeflash_benchmark.plugin"
 
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm"]
+requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/codeflash/discovery/pytest_new_process_discovery.py
+++ b/codeflash/discovery/pytest_new_process_discovery.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
 
     try:
         exitcode = pytest.main(
-            [tests_root, "-p no:logging", "--collect-only", "-m", "not skip"], plugins=[PytestCollectionPlugin()]
+            [tests_root, "-p no:logging", "--collect-only", "-m", "not skip", "-p", "no:codeflash-benchmark"], plugins=[PytestCollectionPlugin()]
         )
     except Exception as e:
         print(f"Failed to collect tests: {e!s}")

--- a/codeflash/discovery/pytest_new_process_discovery.py
+++ b/codeflash/discovery/pytest_new_process_discovery.py
@@ -41,7 +41,8 @@ if __name__ == "__main__":
 
     try:
         exitcode = pytest.main(
-            [tests_root, "-p no:logging", "--collect-only", "-m", "not skip", "-p", "no:codeflash-benchmark"], plugins=[PytestCollectionPlugin()]
+            [tests_root, "-p no:logging", "--collect-only", "-m", "not skip", "-p", "no:codeflash-benchmark"],
+            plugins=[PytestCollectionPlugin()],
         )
     except Exception as e:
         print(f"Failed to collect tests: {e!s}")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -330,7 +330,7 @@ dev = [
 
 [[package]]
 name = "codeflash-benchmark"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "codeflash-benchmark" }
 dependencies = [
     { name = "pytest" },
@@ -549,7 +549,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add comprehensive benchmark CLI options

- Mark certain flags as ignored when tracing

- Remove direct benchmark_disable assignment

- Suppress codeflash plugin in subprocess discovery


___

### Diagram Walkthrough


```mermaid
flowchart LR
  plugin_py["plugin.py: define benchmark_options"] --> addopt_loop["pytest_addoption loop adds options"]
  addopt_loop --> help_suffix["Append ignored suffix when tracing"]
  discovery_py["pytest_new_process_discovery.py"] --> suppress_flag["Add -p no:codeflash-benchmark"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin.py</strong><dd><code>Add benchmark CLI options and tracing behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash-benchmark/codeflash_benchmark/plugin.py

<ul><li>Introduce <code>benchmark_options</code> list of tuples<br> <li> Loop through options to add to parser<br> <li> Append "(ignored when --codeflash-trace)" suffix<br> <li> Remove direct <code>config.option.benchmark_disable</code> call</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/611/files#diff-039a9558833ee717a096651f5c3d06dd9f3b7d010cf140c59141939dc2538c16">+29/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pytest_new_process_discovery.py</strong><dd><code>Suppress codeflash plugin in subprocess</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/discovery/pytest_new_process_discovery.py

<ul><li>Include <code>-p no:codeflash-benchmark</code> flag<br> <li> Prevent plugin interference in subprocess tests</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/611/files#diff-769d09905c7883a45a6193fd64e8f7100e8943bdbc582513cf50c1de082c4a5c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

