### PR TITLE
[Fix] Missing Arguments in create_staging

### DIFF
--- a/codeflash/api/cfapi.py
+++ b/codeflash/api/cfapi.py
@@ -203,6 +203,8 @@ def create_staging(
     generated_original_test_source: str,
     function_trace_id: str,
     coverage_message: str,
+    replay_tests: str,
+    concolic_tests: str,
 ) -> Response:
     """Create a staging pull request, targeting the specified branch. (usually 'staging').
 
@@ -243,6 +245,8 @@ def create_staging(
         "generatedTests": generated_original_test_source,
         "traceId": function_trace_id,
         "coverage_message": coverage_message,
+        "replayTests": replay_tests,
+        "concolicTests": concolic_tests,
     }
 
     return make_cfapi_request(endpoint="/create-staging", method="POST", payload=payload)

--- a/codeflash/api/cfapi.py
+++ b/codeflash/api/cfapi.py
@@ -203,8 +203,8 @@ def create_staging(
     generated_original_test_source: str,
     function_trace_id: str,
     coverage_message: str,
-    replay_tests: str,
-    concolic_tests: str,
+    replay_tests: str = "",
+    concolic_tests: str = "",
 ) -> Response:
     """Create a staging pull request, targeting the specified branch. (usually 'staging').
 


### PR DESCRIPTION
### **User description**
## Summary
A recently added argument to `data` in `process_review` was not passed to `create_staging`, causing an error

## Notes
TODO: Add a GitHub Action to automatically check that staging works correctly when new changes are introduced.


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing `replay_tests` and `concolic_tests` parameters

- Include them in create_staging API payload


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cfapi.py</strong><dd><code>Add missing replay and concolic tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/api/cfapi.py

<ul><li>Added parameters <code>replay_tests</code> and <code>concolic_tests</code><br> <li> Included <code>"replayTests"</code> in payload<br> <li> Included <code>"concolicTests"</code> in payload</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/656/files#diff-4db91bebdd89f96b3b270c5169a5b35a98b0be8806758e0e8e055d7aacf6d4a5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

