### PR TITLE
extend the exclusions, not replace.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ target-version = "py39"
 line-length = 120
 fix = true
 show-fixes = true
-exclude = ["code_to_optimize/", "pie_test_set/", "tests/"]
+extend-exclude = ["code_to_optimize/", "pie_test_set/", "tests/"]
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
a vanilla `extend` replaces the built in ruff https://docs.astral.sh/ruff/settings/#exclude exclusion rules, we want to extend instead.