### PR TITLE
[FIX] Prevent cst duplicate imports

### DIFF
--- a/tests/test_add_needed_imports_from_module.py
+++ b/tests/test_add_needed_imports_from_module.py
@@ -1,7 +1,7 @@
-import re
 from pathlib import Path
 
-from codeflash.code_utils.code_extractor import add_needed_imports_from_module
+from codeflash.code_utils.code_extractor import add_needed_imports_from_module, find_preexisting_objects
+from codeflash.code_utils.code_replacer import replace_functions_and_add_imports
 
 
 def test_add_needed_imports_from_module0() -> None:
@@ -124,7 +124,7 @@ def belongs_to_function(name: Name, function_name: str) -> bool:
     assert new_module == expected
 
 def test_duplicated_imports() -> None:
-    src_module = '''from dataclasses import dataclass
+    optim_code = '''from dataclasses import dataclass
 from recce.adapter.base import BaseAdapter
 from typing import Dict, List, Optional
 
@@ -149,7 +149,7 @@ class DbtAdapter(BaseAdapter):
         return parent_map
 '''
 
-    dst_module = '''import json
+    original_code = '''import json
 import logging
 import os
 import uuid
@@ -241,10 +241,111 @@ class DbtAdapter(BaseAdapter):
 
         return parent_map
 '''
-    src_path = Path("/home/roger/repos/codeflash/cli/codeflash/optimization/function_context.py")
-    dst_path = Path("/home/roger/repos/codeflash/cli/codeflash/optimization/function_context.py")
-    project_root = Path("/home/roger/repos/codeflash")
-    new_module = add_needed_imports_from_module(src_module, dst_module, src_path, dst_path, project_root)
+    expected = '''import json
+import logging
+import os
+import uuid
+from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import dataclass, fields
+from errno import ENOENT
+from functools import lru_cache
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
-    matches = re.findall(r"^\s*from\s+recce\.adapter\.base\s+import\s+BaseAdapter\s*$", new_module, re.MULTILINE)
-    assert len(matches) == 1, f"Expected 1 match for BaseAdapter import, but found {len(matches)}"
+from recce.event import log_performance
+from recce.exceptions import RecceException
+from recce.util.cll import CLLPerformanceTracking, cll
+from recce.util.lineage import (
+    build_column_key,
+    filter_dependency_maps,
+    find_downstream,
+    find_upstream,
+)
+from recce.util.perf_tracking import LineagePerfTracker
+
+from ...tasks.profile import ProfileTask
+from ...util.breaking import BreakingPerformanceTracking, parse_change_category
+
+try:
+    import agate
+    import dbt.adapters.factory
+    from dbt.contracts.state import PreviousState
+except ImportError as e:
+    print("Error: dbt module not found. Please install it by running:")
+    print("pip install dbt-core dbt-<adapter>")
+    raise e
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from recce.adapter.base import BaseAdapter
+from recce.state import ArtifactsRoot
+
+from ...models import RunType
+from ...models.types import (
+    CllColumn,
+    CllData,
+    CllNode,
+    LineageDiff,
+    NodeChange,
+    NodeDiff,
+)
+from ...tasks import (
+    HistogramDiffTask,
+    ProfileDiffTask,
+    QueryBaseTask,
+    QueryDiffTask,
+    QueryTask,
+    RowCountDiffTask,
+    RowCountTask,
+    Task,
+    TopKDiffTask,
+    ValueDiffDetailTask,
+    ValueDiffTask,
+)
+from .dbt_version import DbtVersion
+
+@dataclass
+class DbtAdapter(BaseAdapter):
+
+    def build_parent_map(self, nodes: Dict, base: Optional[bool] = False) -> Dict[str, List[str]]:
+        manifest = self.curr_manifest if base is False else self.base_manifest
+        
+        try:
+            parent_map_source = manifest.parent_map
+        except AttributeError:
+            parent_map_source = manifest.to_dict()["parent_map"]
+
+        node_ids = set(nodes)
+        parent_map = {}
+        for k, parents in parent_map_source.items():
+            if k not in node_ids:
+                continue
+            parent_map[k] = [parent for parent in parents if parent in node_ids]
+
+        return parent_map
+'''
+
+    function_name: str = "DbtAdapter.build_parent_map"
+    preexisting_objects: set[tuple[str, tuple[FunctionParent, ...]]] = find_preexisting_objects(original_code)
+    new_code: str = replace_functions_and_add_imports(
+        source_code=original_code,
+        function_names=[function_name],
+        optimized_code=optim_code,
+        module_abspath=Path(__file__).resolve(),
+        preexisting_objects=preexisting_objects,
+        project_root_path=Path(__file__).resolve().parent.resolve(),
+    )
+    assert new_code == expected

--- a/tests/test_add_needed_imports_from_module.py
+++ b/tests/test_add_needed_imports_from_module.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from codeflash.code_utils.code_extractor import add_needed_imports_from_module
@@ -121,3 +122,129 @@ def belongs_to_function(name: Name, function_name: str) -> bool:
     project_root = Path("/home/roger/repos/codeflash")
     new_module = add_needed_imports_from_module(src_module, dst_module, src_path, dst_path, project_root)
     assert new_module == expected
+
+def test_duplicated_imports() -> None:
+    src_module = '''from dataclasses import dataclass
+from recce.adapter.base import BaseAdapter
+from typing import Dict, List, Optional
+
+@dataclass
+class DbtAdapter(BaseAdapter):
+
+    def build_parent_map(self, nodes: Dict, base: Optional[bool] = False) -> Dict[str, List[str]]:
+        manifest = self.curr_manifest if base is False else self.base_manifest
+        
+        try:
+            parent_map_source = manifest.parent_map
+        except AttributeError:
+            parent_map_source = manifest.to_dict()["parent_map"]
+
+        node_ids = set(nodes)
+        parent_map = {}
+        for k, parents in parent_map_source.items():
+            if k not in node_ids:
+                continue
+            parent_map[k] = [parent for parent in parents if parent in node_ids]
+
+        return parent_map
+'''
+
+    dst_module = '''import json
+import logging
+import os
+import uuid
+from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import dataclass, fields
+from errno import ENOENT
+from functools import lru_cache
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+from recce.event import log_performance
+from recce.exceptions import RecceException
+from recce.util.cll import CLLPerformanceTracking, cll
+from recce.util.lineage import (
+    build_column_key,
+    filter_dependency_maps,
+    find_downstream,
+    find_upstream,
+)
+from recce.util.perf_tracking import LineagePerfTracker
+
+from ...tasks.profile import ProfileTask
+from ...util.breaking import BreakingPerformanceTracking, parse_change_category
+
+try:
+    import agate
+    import dbt.adapters.factory
+    from dbt.contracts.state import PreviousState
+except ImportError as e:
+    print("Error: dbt module not found. Please install it by running:")
+    print("pip install dbt-core dbt-<adapter>")
+    raise e
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from recce.adapter.base import BaseAdapter
+from recce.state import ArtifactsRoot
+
+from ...models import RunType
+from ...models.types import (
+    CllColumn,
+    CllData,
+    CllNode,
+    LineageDiff,
+    NodeChange,
+    NodeDiff,
+)
+from ...tasks import (
+    HistogramDiffTask,
+    ProfileDiffTask,
+    QueryBaseTask,
+    QueryDiffTask,
+    QueryTask,
+    RowCountDiffTask,
+    RowCountTask,
+    Task,
+    TopKDiffTask,
+    ValueDiffDetailTask,
+    ValueDiffTask,
+)
+from .dbt_version import DbtVersion
+
+@dataclass
+class DbtAdapter(BaseAdapter):
+
+    def build_parent_map(self, nodes: Dict, base: Optional[bool] = False) -> Dict[str, List[str]]:
+        manifest = self.curr_manifest if base is False else self.base_manifest
+        manifest_dict = manifest.to_dict()
+
+        node_ids = nodes.keys()
+        parent_map = {}
+        for k, parents in manifest_dict["parent_map"].items():
+            if k not in node_ids:
+                continue
+            parent_map[k] = [parent for parent in parents if parent in node_ids]
+
+        return parent_map
+'''
+    src_path = Path("/home/roger/repos/codeflash/cli/codeflash/optimization/function_context.py")
+    dst_path = Path("/home/roger/repos/codeflash/cli/codeflash/optimization/function_context.py")
+    project_root = Path("/home/roger/repos/codeflash")
+    new_module = add_needed_imports_from_module(src_module, dst_module, src_path, dst_path, project_root)
+
+    matches = re.findall(r"^\s*from\s+recce\.adapter\.base\s+import\s+BaseAdapter\s*$", new_module, re.MULTILINE)
+    assert len(matches) == 1, f"Expected 1 match for BaseAdapter import, but found {len(matches)}"


### PR DESCRIPTION
This fixes the issue here: [https://github.com/misrasaurabh1/recce/pull/30/commits/16f0638dc3840c8c1309fba8389b0421c00cdd31](https://github.com/misrasaurabh1/recce/pull/30/commits/16f0638dc3840c8c1309fba8389b0421c00cdd31)

Basically, `from recce.adapter.base import BaseAdapter` got added even though it was already in the file.

my guess is that `AddImportsVisitor.add_needed_import` stops looking for imports once it hits something that’s not an import. In this case, it hit the `try/except` block within lines 39:46, so it never saw the existing `BaseAdapter` import at line 50 and just added it again.

The fix was to manually collect all top-level imports in a normalized dotted format, so duplicates don’t slip through anymore.
___

### **Description**
- Replace conditional import collector with dotted importer

- Prevent adding duplicate imports in extraction logic

- Update import normalization and alias handling

- Add test for duplicate import removal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  parse["Parse destination module"] --> collect["DottedImportCollector.collect imports"]
  gather["Gather needed imports"] --> filter["Filter out existing imports"]
  filter --> add["AddImportsVisitor.add_needed_import"]
  filter --> remove["RemoveImportsVisitor.remove_unused_import"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>code_extractor.py</strong><dd><code>Refactor import collector and dedupe logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/code_extractor.py

<ul><li>Rename ConditionalImportCollector to DottedImportCollector<br> <li> Normalize top-level imports to dotted format<br> <li> Replace collector usage and invert duplicate import checks<br> <li> Invoke block import collection in visit_Module</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/665/files#diff-d76cd127e1798f120f04726e1a3775840a9870e224395fd25bae32235c6982d0">+31/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_add_needed_imports_from_module.py</strong><dd><code>Add test for duplicate import removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_add_needed_imports_from_module.py

<ul><li>Add import <code>re</code> for regex assertions<br> <li> Introduce <code>test_duplicated_imports</code> for dedupe check<br> <li> Assert only one BaseAdapter import remains</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/665/files#diff-761e9ed15c22dc26c56bc95df70d3267258bb83485ac6d76a8f1a0df0ac19c8f">+127/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

