### PR TITLE
[Lsp] return diff functions grouped by file

### DIFF
--- a/codeflash/lsp/beta.py
+++ b/codeflash/lsp/beta.py
@@ -45,7 +45,7 @@ server = CodeflashLanguageServer("codeflash-language-server", "v1.0", protocol_c
 @server.feature("getOptimizableFunctionsInCurrentDiff")
 def get_functions_in_current_git_diff(
     server: CodeflashLanguageServer, _params: OptimizableFunctionsParams
-) -> dict[str, str | list[str]]:
+) -> dict[str, str | dict[str, list[str]]]:
     functions = get_functions_within_git_diff(uncommitted_changes=True)
     file_to_funcs_to_optimize, _ = filter_functions(
         modified_functions=functions,
@@ -55,8 +55,10 @@ def get_functions_in_current_git_diff(
         module_root=server.optimizer.args.module_root,
         previous_checkpoint_functions={},
     )
-    qualified_names: list[str] = [func.qualified_name for funcs in file_to_funcs_to_optimize.values() for func in funcs]
-    return {"functions": qualified_names, "status": "success"}
+    file_to_qualified_names: dict[str, list[str]] = {
+        str(path): [f.qualified_name for f in funcs] for path, funcs in file_to_funcs_to_optimize.items()
+    }
+    return {"functions": file_to_qualified_names, "status": "success"}
 
 
 @server.feature("getOptimizableFunctions")
@@ -143,7 +145,8 @@ def validate_project(server: CodeflashLanguageServer, _params: FunctionOptimizat
         server.show_message_log("pyproject.toml is not valid", "Error")
         return {
             "status": "error",
-            "message": "pyproject.toml is not valid",  # keep the error message the same, the extension is matching "pyproject.toml" in the error message to show the codeflash init instructions
+            # keep the error message the same, the extension is matching "pyproject.toml" in the error message to show the codeflash init instructions
+            "message": "pyproject.toml is not valid",
         }
 
     args = process_args(server)

--- a/codeflash/lsp/beta.py
+++ b/codeflash/lsp/beta.py
@@ -145,8 +145,7 @@ def validate_project(server: CodeflashLanguageServer, _params: FunctionOptimizat
         server.show_message_log("pyproject.toml is not valid", "Error")
         return {
             "status": "error",
-            # keep the error message the same, the extension is matching "pyproject.toml" in the error message to show the codeflash init instructions
-            "message": "pyproject.toml is not valid",
+            "message": "pyproject.toml is not valid",  # keep the error message the same, the extension is matching "pyproject.toml" in the error message to show the codeflash init instructions
         }
 
     args = process_args(server)


### PR DESCRIPTION
needed for https://github.com/codeflash-ai/codeflash-internal/pull/1761
The lsp client needs to know what is the file for each function to be able to send the optimization request with --file


___

### **Description**
- Group functions by file in current diff

- Change return format to file-to-functions dict

- Update return type annotation


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>beta.py</strong><dd><code>Group functions by file path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/lsp/beta.py

<ul><li>Adjusted <code>get_functions_in_current_git_diff</code> return structure<br> <li> Replaced flat list of functions with file-to-function mapping<br> <li> Updated return type annotation accordingly</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/688/files#diff-dd3ec4fff52172e1820d5983eb3f505a587d3027742bb70bb793b9623c9f3360">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

