### PR TITLE
adjust logging format?

### DIFF
--- a/codeflash/cli_cmds/logging_config.py
+++ b/codeflash/cli_cmds/logging_config.py
@@ -1,4 +1,4 @@
-VERBOSE_LOGGING_FORMAT = "%(asctime)s [%(pathname)s:%(lineno)s in function %(funcName)s] %(message)s"
+VERBOSE_LOGGING_FORMAT = "%(asctime)s [%(pathname)s:%(lineno)s in fn %(funcName)s] %(message)s"
 LOGGING_FORMAT = "[%(levelname)s] %(message)s"
 BARE_LOGGING_FORMAT = "%(message)s"
 
@@ -11,9 +11,16 @@ def set_level(level: int, *, echo_setting: bool = True) -> None:
 
     from codeflash.cli_cmds.console import console
 
+    class RuleAfterLogHandler(RichHandler):
+        def emit(self, record: logging.LogRecord) -> None:
+            super().emit(record)
+            console.rule()
+
     logging.basicConfig(
         level=level,
-        handlers=[RichHandler(rich_tracebacks=True, markup=False, console=console, show_path=False, show_time=False)],
+        handlers=[
+            RuleAfterLogHandler(rich_tracebacks=True, markup=False, console=console, show_path=False, show_time=False)
+        ],
         format=BARE_LOGGING_FORMAT,
     )
     logging.getLogger().setLevel(level)
@@ -23,11 +30,12 @@ def set_level(level: int, *, echo_setting: bool = True) -> None:
             logging.basicConfig(
                 format=VERBOSE_LOGGING_FORMAT,
                 handlers=[
-                    RichHandler(rich_tracebacks=True, markup=False, console=console, show_path=False, show_time=False)
+                    RuleAfterLogHandler(
+                        rich_tracebacks=True, markup=False, console=console, show_path=False, show_time=False
+                    )
                 ],
                 force=True,
             )
             logging.info("Verbose DEBUG logging enabled")
         else:
             logging.info("Logging level set to INFO")
-    console.rule()


### PR DESCRIPTION
### **User description**
small improvement imo, thoughts?


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce RuleAfterLogHandler for log separators

- Replace RichHandler with RuleAfterLogHandler in config

- Update verbose logging format "function" → "fn"

- Remove final console.rule() call


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logging_config.py</strong><dd><code>Use custom handler for log separators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/logging_config.py

<ul><li>Added <code>RuleAfterLogHandler</code> subclass overriding <code>emit</code> to call <br><code>console.rule()</code><br> <li> Switched <code>basicConfig</code> handlers to use <code>RuleAfterLogHandler</code><br> <li> Removed standalone <code>console.rule()</code> at end of <code>set_level</code><br> <li> Updated <code>VERBOSE_LOGGING_FORMAT</code> wording from "function" to "fn"</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/689/files#diff-a2f820f582170ba345da3023e1f702ca7b21962f1cc42f4861cdbb6633349dbb">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

