### PR TITLE
[FIX] allow no quotes in shell export line

### DIFF
--- a/codeflash/code_utils/shell_utils.py
+++ b/codeflash/code_utils/shell_utils.py
@@ -15,7 +15,9 @@ if os.name == "nt":  # Windows
     SHELL_RC_EXPORT_PATTERN = re.compile(r"^set CODEFLASH_API_KEY=(cf-.*)$", re.MULTILINE)
     SHELL_RC_EXPORT_PREFIX = "set CODEFLASH_API_KEY="
 else:
-    SHELL_RC_EXPORT_PATTERN = re.compile(r'^(?!#)export CODEFLASH_API_KEY=[\'"]?(cf-[^\s"]+)[\'"]$', re.MULTILINE)
+    SHELL_RC_EXPORT_PATTERN = re.compile(
+        r'^(?!#)export CODEFLASH_API_KEY=(?:"|\')?(cf-[^\s"\']+)(?:"|\')?$', re.MULTILINE
+    )
     SHELL_RC_EXPORT_PREFIX = "export CODEFLASH_API_KEY="
 
 

--- a/tests/test_shell_utils.py
+++ b/tests/test_shell_utils.py
@@ -64,6 +64,12 @@ class TestReadApiKeyFromShellConfig(unittest.TestCase):
             ) as mock_file:
                 self.assertEqual(read_api_key_from_shell_config(), None)
                 mock_file.assert_called_once_with(self.test_rc_path, encoding="utf8")
+            with patch(
+                "builtins.open", mock_open(read_data=f'export CODEFLASH_API_KEY={self.api_key}\n')
+            ) as mock_file:
+                self.assertEqual(read_api_key_from_shell_config(), self.api_key)
+                mock_file.assert_called_once_with(self.test_rc_path, encoding="utf8")
+
 
     @patch("codeflash.code_utils.shell_utils.get_shell_rc_path")
     def test_no_api_key(self, mock_get_shell_rc_path):


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix regex to match unquoted API key in export

- Allow optional single/double quotes around API key

- Add unit test for unquoted export line


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shell_utils.py</strong><dd><code>Refine shell export regex for API key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/shell_utils.py

<ul><li>Updated regex pattern for non-Windows shells<br> <li> Made quotes around API key optional<br> <li> Captures API key with pattern <code>cf-[^\s"']+</code></ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/715/files#diff-8d76cb604358d4f7ee14584102bfeda361788f405310193ef88801f4eeaa881d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_shell_utils.py</strong><dd><code>Add test for unquoted API key export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_shell_utils.py

<ul><li>Added test for unquoted export line<br> <li> Validates reading API key without quotes</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/715/files#diff-a4cd614642ab34cc96782d51292042a514001cdaa407dd7d839d54e923c4bc10">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

