### PR TITLE
[FIX] Ensure cleanup after each candidate testing (CF-724)

### DIFF
--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -649,16 +649,14 @@ class FunctionOptimizer:
                     if self.args.benchmark and benchmark_tree:
                         console.print(benchmark_tree)
                     console.rule()
-
-                self.write_code_and_helpers(
-                    self.function_to_optimize_source_code, original_helper_code, self.function_to_optimize.file_path
-                )
             except KeyboardInterrupt as e:
-                self.write_code_and_helpers(
-                    self.function_to_optimize_source_code, original_helper_code, self.function_to_optimize.file_path
-                )
                 logger.exception(f"Optimization interrupted: {e}")
                 raise
+            finally:
+                # reset for the next candidate
+                self.write_code_and_helpers(
+                    self.function_to_optimize_source_code, original_helper_code, self.function_to_optimize.file_path
+                )
         if not valid_optimizations:
             return None
         # need to figure out the best candidate here before we return best_optimization


### PR DESCRIPTION

<img width="1908" height="1001" alt="no_replacing" src="https://github.com/user-attachments/assets/7d604162-ff92-4bcf-ad1c-cffa9850dba1" />

If a continue statement is hit inside the try block, the files are not reset, causing the next candidate’s code to be compared against the previous candidate instead of the original code.


___

### **PR Type**
Bug fix


___

### **Description**
- Always reset code after each candidate

- Move cleanup into finally block

- Improve interrupt logging and re-raise


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TryBlock["Candidate evaluation try"] -- may raise --> Except["KeyboardInterrupt handler"]
  TryBlock -- always --> Finally["Finally: reset code/helpers"]
  Except -- log & re-raise --> Propagate["Propagation"]
  Finally -- prepare --> NextCandidate["Next candidate run"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function_optimizer.py</strong><dd><code>Always reset state via finally; improve interrupt handling</code></dd></summary>
<hr>

codeflash/optimization/function_optimizer.py

<ul><li>Move code/helper reset into a finally block.<br> <li> Add exception logging for KeyboardInterrupt, then re-raise.<br> <li> Remove duplicated reset from normal flow/except path.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/742/files#diff-c31e19bcea34bd30ef3c0be56164bea577174363ba3320c4999bf1926ea8ce79">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

