### PR TITLE
import variable correctly

### DIFF
--- a/codeflash/verification/test_runner.py
+++ b/codeflash/verification/test_runner.py
@@ -66,7 +66,7 @@ def run_behavioral_tests(
             "--codeflash_loops_scope=session",
             "--codeflash_min_loops=1",
             "--codeflash_max_loops=1",
-            f"--codeflash_seconds={pytest_target_runtime_seconds}"
+            f"--codeflash_seconds={pytest_target_runtime_seconds}",
         ]
 
         result_file_path = get_run_tmp_file(Path("pytest_results.xml"))


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace import with constant usage

- Remove unused pytest duration args

- Set default benchmarking runtime constant


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TR["test_runner.py"]
  CC["config_consts.TOTAL_LOOPING_TIME_EFFECTIVE"]
  PT["Pytest args cleanup"]
  TR -- "import constant" --> CC
  TR -- "remove --codeflash_seconds" --> PT
  TR -- "default runtime for benchmarking" --> CC
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_runner.py</strong><dd><code>Replace function import and clean pytest args</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/verification/test_runner.py

<ul><li>Import <code>TOTAL_LOOPING_TIME_EFFECTIVE</code> instead of function.<br> <li> Remove <code>pytest_target_runtime_seconds</code> from two functions.<br> <li> Drop <code>--codeflash_seconds</code> from pytest args.<br> <li> Use <code>TOTAL_LOOPING_TIME_EFFECTIVE</code> as default for benchmarking.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/747/files#diff-5f5b0c990536d623ecaf1ddc63e2a18b37c6814d69358652252784db53aedeb2">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

