### PR TITLE
patch apscheduler when tracing

### DIFF
--- a/codeflash/tracing/tracing_new_process.py
+++ b/codeflash/tracing/tracing_new_process.py
@@ -50,7 +50,6 @@ class FakeFrame:
 
 def patch_ap_scheduler() -> None:
     if find_spec("apscheduler"):
-
         import apscheduler.schedulers.background as bg
         import apscheduler.schedulers.blocking as bb
         from apscheduler.schedulers import base

--- a/codeflash/tracing/tracing_new_process.py
+++ b/codeflash/tracing/tracing_new_process.py
@@ -49,7 +49,7 @@ class FakeFrame:
 
 
 def patch_ap_scheduler() -> None:
-    if find_spec("apscheduler") is None:
+    if find_spec("apscheduler"):
 
         import apscheduler.schedulers.background as bg
         import apscheduler.schedulers.blocking as bb
@@ -833,6 +833,7 @@ class Tracer:
 if __name__ == "__main__":
     args_dict = json.loads(sys.argv[-1])
     sys.argv = sys.argv[1:-1]
+    patch_ap_scheduler()
     if args_dict["module"]:
         import runpy
 
@@ -852,7 +853,6 @@ if __name__ == "__main__":
         }
     args_dict["config"]["module_root"] = Path(args_dict["config"]["module_root"])
     args_dict["config"]["tests_root"] = Path(args_dict["config"]["tests_root"])
-    patch_ap_scheduler()
     tracer = Tracer(
         config=args_dict["config"],
         output=Path(args_dict["output"]),

--- a/codeflash/tracing/tracing_new_process.py
+++ b/codeflash/tracing/tracing_new_process.py
@@ -13,6 +13,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
+from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
@@ -45,6 +46,18 @@ class FakeFrame:
         self.f_code = code
         self.f_back = prior
         self.f_locals: dict = {}
+
+
+def patch_ap_scheduler() -> None:
+    if find_spec("apscheduler") is None:
+
+        import apscheduler.schedulers.background as bg
+        import apscheduler.schedulers.blocking as bb
+        from apscheduler.schedulers import base
+
+        bg.BackgroundScheduler.start = lambda _, *_a, **_k: None
+        bb.BlockingScheduler.start = lambda _, *_a, **_k: None
+        base.BaseScheduler.add_job = lambda _, *_a, **_k: None
 
 
 # Debug this file by simply adding print statements. This file is not meant to be debugged by the debugger.
@@ -839,6 +852,7 @@ if __name__ == "__main__":
         }
     args_dict["config"]["module_root"] = Path(args_dict["config"]["module_root"])
     args_dict["config"]["tests_root"] = Path(args_dict["config"]["tests_root"])
+    patch_ap_scheduler()
     tracer = Tracer(
         config=args_dict["config"],
         output=Path(args_dict["output"]),

--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,2 +1,2 @@
 # These version placeholders will be replaced by uv-dynamic-versioning during build.
-__version__ = "0.17.0"
+__version__ = "0.16.7.post46.dev0+444ff121"


### PR DESCRIPTION
### **User description**
apscheduler tries to schedule jobs when the interpreter is shutting down which can cause it to crash and leave us in a bad state


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Patch APScheduler to prevent shutdown crashes

- No-op scheduler start and job add methods

- Invoke patch before tracer initialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import find_spec"] -- "detect apscheduler" --> B["patch_ap_scheduler()"]
  B -- "no-op start/add_job" --> C["Background/Blocking/BaseScheduler"]
  D["runctx"] -- "call" --> B
  D -- "then" --> E["Tracer initialization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracing_new_process.py</strong><dd><code>Patch APScheduler and invoke before tracing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/tracing/tracing_new_process.py

<ul><li>Add <code>find_spec</code> import to detect APScheduler.<br> <li> Introduce <code>patch_ap_scheduler()</code> to no-op scheduler methods.<br> <li> Call <code>patch_ap_scheduler()</code> before creating <code>Tracer</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/761/files#diff-2e3109d7c12cf025ba98aac87fe4dae24bf0f02484c0ecc0bd8b9ef701b610bf">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

