### PR TITLE
Avoid `TypeError: dict.get() takes no keyword arguments` when using env variables with `codeflash optimize`

### DIFF
--- a/codeflash/api/cfapi.py
+++ b/codeflash/api/cfapi.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 from packaging import version
 
-if os.environ.get("CODEFLASH_CFAPI_SERVER", default="prod").lower() == "local":
+if os.environ.get("CODEFLASH_CFAPI_SERVER", "prod").lower() == "local":
     CFAPI_BASE_URL = "http://localhost:3001"
     logger.info(f"Using local CF API at {CFAPI_BASE_URL}.")
     console.rule()


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix env var dict.get usage error

- Prevent TypeError on missing parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ENV["ENV var CODEFLASH_CFAPI_SERVER"] -- "read via os.environ.get(key, default)" --> CFG["Select CFAPI base URL"]
  CFG -- "local" --> LOCAL["Use http://localhost:3001"]
  CFG -- "otherwise" --> PROD["Use default production endpoint"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cfapi.py</strong><dd><code>Fix os.environ.get default argument usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/api/cfapi.py

<ul><li>Replace dict.get default keyword with positional arg<br> <li> Ensure default value "prod" used safely<br> <li> Maintain logic for local vs prod base URL</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/773/files#diff-4db91bebdd89f96b3b270c5169a5b35a98b0be8806758e0e8e055d7aacf6d4a5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

