### PR TITLE
xarray comparator

### DIFF
--- a/codeflash/verification/comparator.py
+++ b/codeflash/verification/comparator.py
@@ -61,6 +61,13 @@ try:
 except ImportError:
     HAS_JAX = False
 
+try:
+    import xarray  # type: ignore
+
+    HAS_XARRAY = True
+except ImportError:
+    HAS_XARRAY = False
+
 
 def comparator(orig: Any, new: Any, superset_obj=False) -> bool:  # noqa: ANN001, ANN401, FBT002, PLR0911
     """Compare two objects for equality recursively. If superset_obj is True, the new object is allowed to have more keys than the original object. However, the existing keys/values must be equivalent."""
@@ -122,6 +129,10 @@ def comparator(orig: Any, new: Any, superset_obj=False) -> bool:  # noqa: ANN001
             if orig.shape != new.shape:
                 return False
             return bool(jnp.allclose(orig, new, equal_nan=True))
+
+        # Handle xarray objects before numpy to avoid boolean context errors
+        if HAS_XARRAY and isinstance(orig, (xarray.Dataset, xarray.DataArray)):
+            return orig.identical(new)
 
         if HAS_SQLALCHEMY:
             try:


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add xarray support in comparator

- Introduce comprehensive xarray test suite

- Prioritize xarray before numpy checks

- Gracefully handle missing xarray import


___

### Diagram Walkthrough


```mermaid
flowchart LR
  comp["comparator()"] -- "detects xarray" --> xra["xarray Dataset/DataArray"]
  xra -- "uses .identical()" --> eq["equality result"]
  tests["tests/test_comparator.py"] -- "validate xarray cases" --> comp
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comparator.py</strong><dd><code>Add xarray-aware comparison in comparator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/verification/comparator.py

<ul><li>Add optional xarray import with feature flag.<br> <li> Compare xarray Dataset/DataArray via identical().<br> <li> Place xarray handling before numpy logic.<br> <li> Maintain safe behavior when xarray absent.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/788/files#diff-a6f2493dbc3f1ec576d03e2d188986f94ca475e3b4cf79ba3dff06309ec01997">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_comparator.py</strong><dd><code>Add comprehensive xarray comparator tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_comparator.py

<ul><li>Add extensive tests for xarray DataArray/Dataset.<br> <li> Cover coords, attrs, shapes, NaN, infinities.<br> <li> Validate type differences and variable mismatches.<br> <li> Skip tests if xarray unavailable.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/788/files#diff-8a94135d1fe94202dcb23b0217c1f7ef21d422d3a72c337836ba3fc85c17dfa6">+120/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

