### PR TITLE
[Worktree] use the git root as the project root

### DIFF
--- a/codeflash/cli_cmds/cli.py
+++ b/codeflash/cli_cmds/cli.py
@@ -11,6 +11,7 @@ from codeflash.cli_cmds.console import logger
 from codeflash.code_utils import env_utils
 from codeflash.code_utils.code_utils import exit_with_message
 from codeflash.code_utils.config_parser import parse_config_file
+from codeflash.code_utils.git_utils import git_root_dir
 from codeflash.lsp.helpers import is_LSP_enabled
 from codeflash.version import __version__ as version
 
@@ -222,18 +223,20 @@ def process_pyproject_config(args: Namespace) -> Namespace:
     args.module_root = Path(args.module_root).resolve()
     # If module-root is "." then all imports are relatives to it.
     # in this case, the ".." becomes outside project scope, causing issues with un-importable paths
-    args.project_root = project_root_from_module_root(args.module_root, pyproject_file_path)
+    args.project_root = project_root_from_module_root(args.module_root, pyproject_file_path, args.worktree)
     args.tests_root = Path(args.tests_root).resolve()
     if args.benchmarks_root:
         args.benchmarks_root = Path(args.benchmarks_root).resolve()
-    args.test_project_root = project_root_from_module_root(args.tests_root, pyproject_file_path)
+    args.test_project_root = project_root_from_module_root(args.tests_root, pyproject_file_path, args.worktree)
     if is_LSP_enabled():
         args.all = None
         return args
     return handle_optimize_all_arg_parsing(args)
 
 
-def project_root_from_module_root(module_root: Path, pyproject_file_path: Path) -> Path:
+def project_root_from_module_root(module_root: Path, pyproject_file_path: Path, in_worktree: bool = False) -> Path:  # noqa: FBT001, FBT002
+    if in_worktree:
+        return git_root_dir()
     if pyproject_file_path.parent == module_root:
         return module_root
     return module_root.parent.resolve()


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Use Git root as project root in worktrees

- Add worktree-aware project root resolution

- Update args roots via new logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI args parsing"] -- "module/tests roots" --> B["project_root_from_module_root"]
  B -- "in worktree" --> C["git_root_dir()"]
  B -- "not in worktree" --> D["derive from module_root/pyproject"]
  C -- "set project_root & test_project_root" --> E["args updated"]
  D -- "set project_root & test_project_root" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Worktree-aware project root resolution via git root</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cli.py

<ul><li>Import <code>git_root_dir</code> from <code>git_utils</code>.<br> <li> Pass <code>args.worktree</code> to project root resolver.<br> <li> Use Git root when in worktree for project roots.<br> <li> Keep legacy logic when not in worktree.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/790/files#diff-21f18b94ebed099d24b96475865ff5c2ac245020f73a6b8de0c3790c7a46b2ad">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

