### PR TITLE
fix pytest_rootdir being set to None when pkl is not available

### DIFF
--- a/codeflash/discovery/discover_unit_tests.py
+++ b/codeflash/discovery/discover_unit_tests.py
@@ -417,6 +417,7 @@ def discover_tests_pytest(
         with tmp_pickle_path.open(mode="rb") as f:
             exitcode, tests, pytest_rootdir = pickle.load(f)
     except Exception as e:
+        tests, pytest_rootdir = [], None
         logger.exception(f"Failed to discover tests: {e}")
         exitcode = -1
     finally:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Prevent None pytest_rootdir on pickle failure

- Default to empty tests list on exception

- Improve robustness of pytest discovery cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Run pytest discovery subprocess"] -- "writes pickle" --> B["Read tmp pickle"]
  B -- "load succeeds" --> C["exitcode, tests, pytest_rootdir"]
  B -- "load fails (Exception)" --> D["tests=[], pytest_rootdir=None; exitcode=-1"]
  C -- "cleanup" --> E["unlink tmp pickle"]
  D -- "cleanup" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>discover_unit_tests.py</strong><dd><code>Handle pickle load errors with safe defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/discovery/discover_unit_tests.py

<ul><li>On pickle load exception, set <code>tests=[]</code> and <code>pytest_rootdir=None</code><br> <li> Preserve logging of exception and set <code>exitcode=-1</code><br> <li> Ensure temp pickle file is unlinked in finally</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/797/files#diff-d4a934ababd112412f396a9574cfd3d3bec4a7cff98dd6b29d1505bccf24987a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

