### PR TITLE
Migrate pygls to v2

### DIFF
--- a/codeflash/lsp/beta.py
+++ b/codeflash/lsp/beta.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from pygls import uris
-
 from codeflash.api.cfapi import get_codeflash_api_key, get_user_id
 from codeflash.cli_cmds.cli import process_pyproject_config
 from codeflash.code_utils.git_utils import git_root_dir
@@ -111,7 +109,11 @@ def _group_functions_by_file(
 def get_optimizable_functions(
     server: CodeflashLanguageServer, params: OptimizableFunctionsParams
 ) -> dict[str, list[str]]:
-    file_path = Path(uris.to_fs_path(params.textDocument.uri))
+    document_uri = params.textDocument.uri
+    document = server.workspace.get_text_document(document_uri)
+
+    file_path = Path(document.path)
+
     if not server.optimizer:
         return {"status": "error", "message": "optimizer not initialized"}
 
@@ -264,8 +266,10 @@ def provide_api_key(server: CodeflashLanguageServer, params: ProvideApiKeyParams
 def initialize_function_optimization(
     server: CodeflashLanguageServer, params: FunctionOptimizationInitParams
 ) -> dict[str, str]:
-    file_path = Path(uris.to_fs_path(params.textDocument.uri))
-    server.show_message_log(f"Initializing optimization for function: {params.functionName} in {file_path}", "Info")
+    document_uri = params.textDocument.uri
+    document = server.workspace.get_text_document(document_uri)
+
+    server.show_message_log(f"Initializing optimization for function: {params.functionName} in {document_uri}", "Info")
 
     if server.optimizer is None:
         _initialize_optimizer_if_api_key_is_valid(server)
@@ -275,7 +279,7 @@ def initialize_function_optimization(
     original_args, _ = server.optimizer.original_args_and_test_cfg
 
     server.optimizer.args.function = params.functionName
-    original_relative_file_path = file_path.relative_to(original_args.project_root)
+    original_relative_file_path = Path(document.path).relative_to(original_args.project_root)
     server.optimizer.args.file = server.optimizer.current_worktree / original_relative_file_path
     server.optimizer.args.previous_checkpoint_functions = False
 

--- a/codeflash/lsp/server.py
+++ b/codeflash/lsp/server.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from lsprotocol.types import LogMessageParams, MessageType
+from pygls.lsp.server import LanguageServer
 from pygls.protocol import LanguageServerProtocol
-from pygls.server import LanguageServer
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -56,7 +56,7 @@ class CodeflashLanguageServer(LanguageServer):
 
         # Send log message to client (appears in output channel)
         log_params = LogMessageParams(type=lsp_message_type, message=message)
-        self.lsp.notify("window/logMessage", log_params)
+        self.protocol.notify("window/logMessage", log_params)
 
     def cleanup_the_optimizer(self) -> None:
         self.current_optimization_init_result = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "coverage>=7.6.4",
     "line_profiler>=4.2.0",
     "platformdirs>=4.3.7",
-    "pygls>=1.3.1",
+    "pygls>=2.0.0,<3.0.0",
     "codeflash-benchmark",
     "filelock",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -410,7 +410,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.3.7" },
     { name = "posthog", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=1.10.1" },
-    { name = "pygls", specifier = ">=1.3.1" },
+    { name = "pygls", specifier = ">=2.0.0,<3.0.0" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'asyncio'", specifier = ">=1.2.0" },
     { name = "pytest-timeout", specifier = ">=2.1.0" },
@@ -1344,15 +1344,15 @@ wheels = [
 
 [[package]]
 name = "lsprotocol"
-version = "2023.0.1"
+version = "2025.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "cattrs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434, upload-time = "2024-01-09T17:21:12.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/37/2351e48cb3309673492d3a8c59d407b75fb6630e560eb27ecd4da03adc9a/lsprotocol-2023.0.1-py3-none-any.whl", hash = "sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2", size = 70826, upload-time = "2024-01-09T17:21:14.491Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
 ]
 
 [[package]]
@@ -2560,15 +2560,16 @@ wheels = [
 
 [[package]]
 name = "pygls"
-version = "1.3.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "attrs" },
     { name = "cattrs" },
     { name = "lsprotocol" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/b9/41d173dad9eaa9db9c785a85671fc3d68961f08d67706dc2e79011e10b5c/pygls-1.3.1.tar.gz", hash = "sha256:140edceefa0da0e9b3c533547c892a42a7d2fd9217ae848c330c53d266a55018", size = 45527, upload-time = "2024-03-26T18:44:25.679Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/50/2bfc32f3acbc8941042919b59c9f592291127b55d7331b72e67ce7b62f08/pygls-2.0.0.tar.gz", hash = "sha256:99accd03de1ca76fe1e7e317f0968ebccf7b9955afed6e2e3e188606a20b4f07", size = 55796, upload-time = "2025-10-17T19:22:47.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/19/b74a10dd24548e96e8c80226cbacb28b021bc3a168a7d2709fb0d0185348/pygls-1.3.1-py3-none-any.whl", hash = "sha256:6e00f11efc56321bdeb6eac04f6d86131f654c7d49124344a9ebb968da3dd91e", size = 56031, upload-time = "2024-03-26T18:44:24.249Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/09/14feafc13bebb9c85b29b374889c1549d3700cb572f2d43a1bb940d70315/pygls-2.0.0-py3-none-any.whl", hash = "sha256:b4e54bba806f76781017ded8fd07463b98670f959042c44170cd362088b200cc", size = 69533, upload-time = "2025-10-17T19:22:46.63Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Migrate to pygls v2 API

- Replace uri handling with workspace document

- Update logging to use protocol.notify

- Bump dependency to pygls v2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  deps["pyproject: pygls >=2,<3"]
  uris["Remove uris.to_fs_path usage"]
  docs["Use workspace.get_text_document"]
  log["Use protocol.notify for logs"]
  paths["Derive Path from document.path"]

  deps -- "runtime requirement" --> server["LSP Server"]
  uris -- "v2 migration" --> docs
  docs -- "retrieve document" --> paths
  log -- "v2 API change" --> server
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>beta.py</strong><dd><code>Switch to workspace document-based path handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/lsp/beta.py

<ul><li>Stop using <code>uris.to_fs_path</code>.<br> <li> Get document via <code>server.workspace.get_text_document</code>.<br> <li> Use <code>document.path</code> to build <code>Path</code> and relatives.<br> <li> Update log message to use document URI.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/840/files#diff-dd3ec4fff52172e1820d5983eb3f505a587d3027742bb70bb793b9623c9f3360">+10/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Update LanguageServer imports and notify API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/lsp/server.py

<ul><li>Import <code>LanguageServer</code> from <code>pygls.lsp.server</code>.<br> <li> Use <code>self.protocol.notify</code> for window/logMessage.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/840/files#diff-57c5fb2bd3572c756fcab246eff6537406cd98f91d5089da8b6a61d44f16f909">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Pin dependency to pygls v2 range</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bump `pygls` requirement to `>=2.0.0,<3.0.0`.


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/840/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

