### PR TITLE
warn user to run codeflash init if config not found

### DIFF
--- a/codeflash/code_utils/config_parser.py
+++ b/codeflash/code_utils/config_parser.py
@@ -6,7 +6,6 @@ from typing import Any
 import tomlkit
 
 from codeflash.lsp.helpers import is_LSP_enabled
-from codeflash.cli_cmds.console import logger
 
 PYPROJECT_TOML_CACHE = {}
 ALL_CONFIG_FILES = {}  # map path to closest config file


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Require `tool["codeflash"]` in config parsing

- Add console logger import to module

- Preserve LSP fallback when config missing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  parser["config_parser.parse_config_file"] --> access["Access tool[\"codeflash\"]"]
  access -- "missing in LSP" --> lspFallback["Return {}, path"]
  access -- "present" --> proceed["Use explicit config"]
  module["Module imports"] --> loggerImport["Add console logger import"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_parser.py</strong><dd><code>Enforce config presence and add logger import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/code_utils/config_parser.py

<ul><li>Import <code>logger</code> from <code>codeflash.cli_cmds.console</code>.<br> <li> Access config via <code>tool["codeflash"]</code> instead of <code>get</code>.<br> <li> Maintain LSP mode fallback when config is absent.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/882/files#diff-0a10492dab4c0b830ed2a6f8fac08827d9976ff942013f6cbedb11d02e9df802">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

