### PR TITLE
remove failing generated tests

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -372,6 +372,7 @@ dev = [
 ]
 tests = [
     { name = "black" },
+    { name = "eval-type-backport" },
     { name = "jax", version = "0.4.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "jax", version = "0.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -451,6 +452,7 @@ dev = [
 ]
 tests = [
     { name = "black", specifier = ">=25.9.0" },
+    { name = "eval-type-backport" },
     { name = "jax", specifier = ">=0.4.30" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "pandas", specifier = ">=2.3.3" },
@@ -697,6 +699,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/92/734a4ab345914259cb6146fd36512608ea42be16195375c379046f33283d/editor-1.6.6.tar.gz", hash = "sha256:bb6989e872638cd119db9a4fce284cd8e13c553886a1c044c6b8d8a160c871f8", size = 3197, upload-time = "2024-01-25T10:44:59.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/c2/4bc8cd09b14e28ce3f406a8b05761bed0d785d1ca8c2a5c6684d884c66a2/editor-1.6.6-py3-none-any.whl", hash = "sha256:e818e6913f26c2a81eadef503a2741d7cca7f235d20e217274a009ecd5a74abf", size = 4017, upload-time = "2024-01-25T10:44:58.66Z" },
+]
+
+[[package]]
+name = "eval-type-backport"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/ea/8b0ac4469d4c347c6a385ff09dc3c048c2d021696664e26c7ee6791631b5/eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1", size = 9079, upload-time = "2024-12-21T20:09:46.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/31/55cd413eaccd39125368be33c46de24a1f639f2e12349b0361b4678f3915/eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a", size = 5830, upload-time = "2024-12-21T20:09:44.175Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Auto-remove failing generated regression tests

- Add async safety by pruning bad tests early

- Insert console rule after cleanup step

- Minor typing: import `Pattern` for regex use


___

### Diagram Walkthrough


```mermaid
flowchart LR
  setup["Test setup completed"] -- "run behavior tests" --> run["Run and parse tests"]
  run -- "collect failing generated tests" --> collect["Failing test names"]
  collect -- "compile regex patterns" --> compile["Compile function patterns"]
  compile -- "remove from sources" --> apply["Delete tests in files"]
  apply -- "log and continue" --> proceed["Establish baseline & optimize"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>function_optimizer.py</strong><dd><code>Pre-baseline pruning of failing generated tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/function_optimizer.py

<ul><li>Add <code>remove_failing_tests</code> to prune bad generated tests<br> <li> Add <code>remove_tests_from_source</code> with regex-based deletion<br> <li> Invoke removal before establishing baseline; add console rule<br> <li> Add TYPE_CHECKING import for <code>Pattern</code></ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/894/files#diff-c31e19bcea34bd30ef3c0be56164bea577174363ba3320c4999bf1926ea8ce79">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

