### PR TITLE
[Chore] Better config file validation for the lsp

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -171,10 +171,23 @@ def ask_run_end_to_end_test(args: Namespace) -> None:
         run_end_to_end_test(args, file_path)
 
 
-def is_valid_pyproject_toml(pyproject_toml_path: Path) -> tuple[bool, dict[str, Any] | None, str]:  # noqa: PLR0911
-    if not pyproject_toml_path.exists():
-        return False, None, f"Configuration file not found: {pyproject_toml_path}"
+def config_found(pyproject_toml_path: Union[str, Path]) -> tuple[bool, str]:
+    pyproject_toml_path = Path(pyproject_toml_path)
 
+    if not pyproject_toml_path.exists():
+        return False, f"Configuration file not found: {pyproject_toml_path}"
+
+    if not pyproject_toml_path.is_file():
+        return False, f"Configuration file is not a file: {pyproject_toml_path}"
+
+    if pyproject_toml_path.suffix != ".toml":
+        return False, f"Configuration file is not a .toml file: {pyproject_toml_path}"
+
+    return True, ""
+
+
+def is_valid_pyproject_toml(pyproject_toml_path: Union[str, Path]) -> tuple[bool, dict[str, Any] | None, str]:
+    pyproject_toml_path = Path(pyproject_toml_path)
     try:
         config, _ = parse_config_file(pyproject_toml_path)
     except Exception as e:
@@ -205,6 +218,10 @@ def should_modify_pyproject_toml() -> tuple[bool, dict[str, Any] | None]:
     from rich.prompt import Confirm
 
     pyproject_toml_path = Path.cwd() / "pyproject.toml"
+
+    found, _ = config_found(pyproject_toml_path)
+    if not found:
+        return True, None
 
     valid, config, _message = is_valid_pyproject_toml(pyproject_toml_path)
     if not valid:

--- a/codeflash/lsp/beta.py
+++ b/codeflash/lsp/beta.py
@@ -14,6 +14,7 @@ from codeflash.cli_cmds.cli import process_pyproject_config
 from codeflash.cli_cmds.cmd_init import (
     CommonSections,
     VsCodeSetupInfo,
+    config_found,
     configure_pyproject_toml,
     create_empty_pyproject_toml,
     create_find_common_tags_file,
@@ -262,6 +263,10 @@ def init_project(params: ValidateProjectParams) -> dict[str, str]:
             "pyprojectPath": pyproject_toml_path,
             "root": root,
         }
+
+    found, message = config_found(pyproject_toml_path)
+    if not found:
+        return {"status": "error", "message": message}
 
     valid, config, reason = is_valid_pyproject_toml(pyproject_toml_path)
     if not valid:


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `config_found` for pre-parse checks

- Validate path, file type, and suffix

- Use early config existence validation

- Improve LSP init error messaging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Caller (CLI/LSP)"] --> B["config_found(path)"]
  B -- "not found/invalid" --> E["Return error early"]
  B -- "found" --> C["is_valid_pyproject_toml(path)"]
  C -- "valid" --> D["Proceed (init/confirm)"]
  C -- "invalid" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cmd_init.py</strong><dd><code>Introduce pre-parse config checks and refactor validation</code></dd></summary>
<hr>

codeflash/cli_cmds/cmd_init.py

<ul><li>Add <code>config_found</code> with path/file/suffix checks<br> <li> Refactor <code>is_valid_pyproject_toml</code> signature to accept <code>Union[str, Path]</code><br> <li> Early-return in <code>should_modify_pyproject_toml</code> when config missing<br> <li> Improve parse error message propagation</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/912/files#diff-c15be1c100e57b623163c38b4995067f137d3ad0cf5c3e8cebeaa2f32ef86fc8">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>beta.py</strong><dd><code>LSP init uses early config existence validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/lsp/beta.py

<ul><li>Import and use <code>config_found</code> before parsing<br> <li> Early error return with informative message in <code>init_project</code></ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/912/files#diff-dd3ec4fff52172e1820d5983eb3f505a587d3027742bb70bb793b9623c9f3360">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

