### PR TITLE
[VSC] pyproject setup fix

### DIFF
--- a/codeflash/lsp/beta.py
+++ b/codeflash/lsp/beta.py
@@ -207,15 +207,28 @@ def get_config_suggestions(_params: any) -> dict[str, any]:
     formatter_suggestions, default_formatter = get_suggestions(CommonSections.formatter_cmds)
     get_valid_subdirs.cache_clear()
 
-    configured_module_root = Path(server.args.module_root).relative_to(Path.cwd()) if server.args.module_root else None
-    configured_tests_root = Path(server.args.tests_root).relative_to(Path.cwd()) if server.args.tests_root else None
-    configured_test_framework = server.args.test_framework if server.args.test_framework else None
-
+    try:
+        configured_module_root = (
+            Path(server.args.module_root).relative_to(Path.cwd()) if server.args.module_root else None
+        )
+    except:  # noqa : E722
+        configured_module_root = None
+    try:
+        configured_tests_root = Path(server.args.tests_root).relative_to(Path.cwd()) if server.args.tests_root else None
+    except:  # noqa : E722
+        configured_tests_root = None
+    try:
+        configured_test_framework = server.args.test_framework if server.args.test_framework else None
+    except:  # noqa : E722
+        configured_test_framework = None
     configured_formatter = ""
-    if isinstance(server.args.formatter_cmds, list):
-        configured_formatter = " && ".join([cmd.strip() for cmd in server.args.formatter_cmds])
-    elif isinstance(server.args.formatter_cmds, str):
-        configured_formatter = server.args.formatter_cmds.strip()
+    try:
+        if isinstance(server.args.formatter_cmds, list):
+            configured_formatter = " && ".join([cmd.strip() for cmd in server.args.formatter_cmds])
+        elif isinstance(server.args.formatter_cmds, str):
+            configured_formatter = server.args.formatter_cmds.strip()
+    except:  # noqa : E722
+        configured_formatter = "disabled"
 
     return {
         "module_root": {"choices": module_root_suggestions, "default": configured_module_root or default_module_root},


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add defensive try/except around arg parsing

- Prevent crashes on invalid VSC config

- Default formatter to "disabled" on errors

- Clear subdir cache before suggestion build


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Args["Server args"] -- "parse with try/except" --> Parsed["Configured values or None"]
  Parsed -- "fallback to defaults" --> Defaults["Default suggestions"]
  Formatter["formatter_cmds"] -- "join/strip or error" --> FormatterOut["Configured or 'disabled'"]
  Defaults -- "assemble response" --> Output["Config suggestions dict"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>beta.py</strong><dd><code>Robust arg parsing with safe fallbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/lsp/beta.py

<ul><li>Wrap module/tests root parsing in try/except.<br> <li> Guard test framework extraction with try/except.<br> <li> Safely build formatter command, defaulting to "disabled" on errors.<br> <li> Maintain cache clear; return defaults when config invalid.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/919/files#diff-dd3ec4fff52172e1820d5983eb3f505a587d3027742bb70bb793b9623c9f3360">+21/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

