### PR TITLE
[Chore] Validate API key in the init flow

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -22,7 +22,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from codeflash.api.cfapi import is_github_app_installed_on_repo
+from codeflash.api.cfapi import get_user_id, is_github_app_installed_on_repo
 from codeflash.cli_cmds.cli_common import apologize_and_exit
 from codeflash.cli_cmds.console import console, logger
 from codeflash.cli_cmds.extension import install_vscode_extension
@@ -1216,6 +1216,7 @@ def enter_api_key_and_save_to_rc() -> None:
         # On Windows, create a batch file in the user's home directory (not auto-run, just used to store api key)
         shell_rc_path.touch()
         click.echo(f"✅ Created {shell_rc_path}")
+    get_user_id(api_key=api_key)  # Used to verify whether the API key is valid.
     result = save_api_key_to_rc(api_key)
     if is_successful(result):
         click.echo(result.unwrap())


### PR DESCRIPTION
### **User description**
fixes CF-864


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Validate API key during init flow

- Import and call `get_user_id` for verification

- Preserve existing API key save behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  init["init flow"] --> prompt["Prompt for API key"]
  prompt --> verify["Call get_user_id(api_key)"]
  verify -- "valid" --> save["Save API key to rc"]
  verify -- "invalid (raises)" --> exit["apologize_and_exit / error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cmd_init.py</strong><dd><code>Add API key validation via get_user_id</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/cli_cmds/cmd_init.py

<ul><li>Import <code>get_user_id</code> from <code>codeflash.api.cfapi</code>.<br> <li> Call <code>get_user_id(api_key)</code> before saving key to rc.<br> <li> Use call as validation step in init flow.</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/932/files#diff-c15be1c100e57b623163c38b4995067f137d3ad0cf5c3e8cebeaa2f32ef86fc8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

