### PR TITLE
Exposing Behavior test run as a tool call to LLMs

### DIFF
--- a/codeflash/verification/__init__.py
+++ b/codeflash/verification/__init__.py
@@ -4,7 +4,7 @@ This module provides test running and verification functionality.
 """
 
 
-def __getattr__(name: str):  # noqa: ANN202
+def __getattr__(name: str) -> object:
     """Lazy import for LLM tools to avoid circular imports."""
     if name in (
         "AVAILABLE_TOOLS",

--- a/tests/test_llm_tools.py
+++ b/tests/test_llm_tools.py
@@ -15,17 +15,20 @@ from codeflash.verification.llm_tools import (
 )
 
 
-def test_run_behavioral_tests_tool_schema_structure():
+def test_run_behavioral_tests_tool_schema_structure() -> None:
     """Test that the tool schema has the correct structure."""
     schema = RUN_BEHAVIORAL_TESTS_TOOL_SCHEMA
 
     assert schema["type"] == "function"
     assert "function" in schema
-    assert schema["function"]["name"] == "run_behavioral_tests"
-    assert "description" in schema["function"]
-    assert "parameters" in schema["function"]
+    func = schema["function"]
+    assert isinstance(func, dict)
+    assert func["name"] == "run_behavioral_tests"
+    assert "description" in func
+    assert "parameters" in func
 
-    params = schema["function"]["parameters"]
+    params = func["parameters"]
+    assert isinstance(params, dict)
     assert params["type"] == "object"
     assert "test_files" in params["properties"]
     assert "project_root" in params["properties"]
@@ -34,7 +37,7 @@ def test_run_behavioral_tests_tool_schema_structure():
     assert "project_root" in params["required"]
 
 
-def test_get_tool_schema():
+def test_get_tool_schema() -> None:
     """Test getting tool schema by name."""
     schema = get_tool_schema("run_behavioral_tests")
     assert schema is not None
@@ -44,7 +47,7 @@ def test_get_tool_schema():
     assert get_tool_schema("non_existent_tool") is None
 
 
-def test_get_all_tool_schemas():
+def test_get_all_tool_schemas() -> None:
     """Test getting all tool schemas."""
     schemas = get_all_tool_schemas()
     assert isinstance(schemas, list)
@@ -55,7 +58,7 @@ def test_get_all_tool_schemas():
     assert "run_behavioral_tests" in names
 
 
-def test_available_tools_registry():
+def test_available_tools_registry() -> None:
     """Test that the AVAILABLE_TOOLS registry has correct structure."""
     assert "run_behavioral_tests" in AVAILABLE_TOOLS
 
@@ -65,13 +68,13 @@ def test_available_tools_registry():
     assert callable(tool["function"])
 
 
-def test_execute_tool_unknown_tool():
+def test_execute_tool_unknown_tool() -> None:
     """Test that execute_tool raises ValueError for unknown tools."""
     with pytest.raises(ValueError, match="Unknown tool"):
         execute_tool("non_existent_tool")
 
 
-def test_run_behavioral_tests_tool_pytest():
+def test_run_behavioral_tests_tool_pytest() -> None:
     """Test running pytest tests through the LLM tool."""
     test_code = """
 def add(a, b):
@@ -104,7 +107,7 @@ def test_add():
         assert isinstance(result["results"], list)
 
 
-def test_run_behavioral_tests_tool_failing_test():
+def test_run_behavioral_tests_tool_failing_test() -> None:
     """Test running a failing test through the LLM tool."""
     test_code = """
 def test_failing():
@@ -128,7 +131,7 @@ def test_failing():
         assert result["failed_tests"] >= 1
 
 
-def test_run_behavioral_tests_tool_via_execute():
+def test_run_behavioral_tests_tool_via_execute() -> None:
     """Test running tests through the execute_tool interface."""
     test_code = """
 def test_simple():
@@ -151,7 +154,7 @@ def test_simple():
         assert result["error"] is None
 
 
-def test_run_behavioral_tests_tool_invalid_path():
+def test_run_behavioral_tests_tool_invalid_path() -> None:
     """Test handling of invalid test file path."""
     # Use repo root for project_root
     repo_root = Path(__file__).resolve().parent.parent
@@ -167,7 +170,7 @@ def test_run_behavioral_tests_tool_invalid_path():
     assert result["total_tests"] == 0
 
 
-def test_run_behavioral_tests_tool_with_test_type():
+def test_run_behavioral_tests_tool_with_test_type() -> None:
     """Test specifying test type."""
     test_code = """
 def test_with_type():


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Expose behavioral tests as LLM tool

- Add tool schema and execution registry

- Provide lazy imports to avoid cycles

- Add comprehensive tests for tool API


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LLM["LLM"] -- "calls tool" --> Exec["execute_tool()"]
  Exec -- "dispatch" --> Tool["run_behavioral_tests_tool()"]
  Tool -- "invoke" --> Runner["run_behavioral_tests()"]
  Runner -- "produce JUnit XML" --> Parser["parse_test_xml()"]
  Parser -- "results" --> Tool
  Tool -- "structured dict" --> LLM
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Lazy export of verification LLM tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/verification/__init__.py

<ul><li>Add lazy attribute loader for LLM tools<br> <li> Re-export tool APIs via __all__</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/949/files#diff-c4d87eee2580987ffa336d81272d5b00f9895c803ce96be9127b21ff937b64fb">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>llm_tools.py</strong><dd><code>LLM tool schema and behavior test wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/verification/llm_tools.py

<ul><li>Define JSON schema for <code>run_behavioral_tests</code><br> <li> Implement <code>run_behavioral_tests_tool</code> wrapper<br> <li> Add tool registry and execution helpers<br> <li> Map string test types to enum</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/949/files#diff-c58b74ea02aa9a327db2eda6311781d4402a6f3fcd8bfebdf15e07baf0378b24">+321/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_llm_tools.py</strong><dd><code>Tests for verification LLM tools interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_llm_tools.py

<ul><li>Add tests for tool schema and registry<br> <li> Validate execute_tool dispatch and errors<br> <li> Run real pytest samples through tool<br> <li> Test handling of failing and invalid paths</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/949/files#diff-4d13c8a2f4d5ab55a0bfb38f4e9c3d4bc6ef4fd2065aa904bfa97bf4f59e56ea">+193/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

