### PR TITLE
[FIX] incorrect PR message shown when --no-pr flag is passed

### DIFF
--- a/codeflash/discovery/functions_to_optimize.py
+++ b/codeflash/discovery/functions_to_optimize.py
@@ -25,7 +25,6 @@ from codeflash.code_utils.code_utils import (
 )
 from codeflash.code_utils.env_utils import get_pr_number
 from codeflash.code_utils.git_utils import get_git_diff, get_repo_owner_and_name
-from codeflash.code_utils.time_utils import humanize_runtime
 from codeflash.discovery.discover_unit_tests import discover_unit_tests
 from codeflash.lsp.helpers import is_LSP_enabled
 from codeflash.models.models import FunctionParent
@@ -244,13 +243,6 @@ def get_functions_to_optimize(
         )
 
         logger.info(f"!lsp|Found {functions_count} function{'s' if functions_count > 1 else ''} to optimize")
-        if optimize_all:
-            three_min_in_ns = int(1.8e11)
-            console.rule()
-            logger.info(
-                f"It might take about {humanize_runtime(functions_count * three_min_in_ns)} to fully optimize this project. Codeflash "
-                f"will keep opening pull requests as it finds optimizations."
-            )
         return filtered_modified_functions, functions_count, trace_file_path
 
 

--- a/codeflash/optimization/optimizer.py
+++ b/codeflash/optimization/optimizer.py
@@ -22,6 +22,7 @@ from codeflash.code_utils.git_worktree_utils import (
     create_worktree_snapshot_commit,
     remove_worktree,
 )
+from codeflash.code_utils.time_utils import humanize_runtime
 from codeflash.either import is_successful
 from codeflash.models.models import ValidCode
 from codeflash.telemetry.posthog_cf import ph
@@ -270,6 +271,16 @@ class Optimizer:
 
         function_optimizer = None
         file_to_funcs_to_optimize, num_optimizable_functions, trace_file_path = self.get_optimizable_functions()
+        if self.args.all:
+            three_min_in_ns = int(1.8e11)
+            console.rule()
+            pr_message = (
+                "\nCodeflash will keep opening pull requests as it finds optimizations." if not self.args.no_pr else ""
+            )
+            logger.info(
+                f"It might take about {humanize_runtime(num_optimizable_functions * three_min_in_ns)} to fully optimize this project.{pr_message}"
+            )
+
         function_benchmark_timings, total_benchmark_timings = self.run_benchmarks(
             file_to_funcs_to_optimize, num_optimizable_functions
         )


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Move ETA message to optimizer run flow

- Respect '--no-pr' in ETA messaging

- Remove duplicate messaging from discovery path

- Import 'humanize_runtime' where used


___

### Diagram Walkthrough


```mermaid
flowchart LR
  discovery["discovery/functions_to_optimize.py\n(remove ETA + PR message)"]
  optimizer["optimization/optimizer.py\n(add ETA + PR-aware message)"]
  timeutils["code_utils.time_utils.humanize_runtime\n(import here)"]

  discovery -- "remove message and import" --> optimizer
  timeutils -- "ETA formatting" --> optimizer
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>functions_to_optimize.py</strong><dd><code>Remove redundant ETA messaging from discovery</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/discovery/functions_to_optimize.py

<ul><li>Remove ETA and PR message for --all path<br> <li> Drop unused 'humanize_runtime' import<br> <li> Keep logging of functions count</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/958/files#diff-adb17c14509d2bdc69ea39d82dfdde9c4c1c30277f9c8765b74ebb016b0c3cb3">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>optimizer.py</strong><dd><code>Centralize ETA and PR-aware messaging in optimizer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

codeflash/optimization/optimizer.py

<ul><li>Add ETA logging when '--all' is set<br> <li> Respect '--no-pr' by adjusting message<br> <li> Import 'humanize_runtime' for ETA formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/codeflash-ai/codeflash/pull/958/files#diff-d242b27fa098f222741a48a7daa8e421433b4c5e19dd38512404cd000df144a0">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

