### PR TITLE
Disable the adaptive optimization until we have the effort param.

### DIFF
--- a/codeflash/code_utils/config_consts.py
+++ b/codeflash/code_utils/config_consts.py
@@ -38,7 +38,10 @@ MAX_REPAIRS_PER_TRACE = 4  # maximum number of repairs we will do for each funct
 # Adaptive optimization
 # TODO (ali): make this configurable with effort arg once the PR is merged
 ADAPTIVE_OPTIMIZATION_THRESHOLD = 2  # Max adaptive optimizations per single candidate tree (for example : optimize -> refine -> adaptive -> another adaptive).
-MAX_ADAPTIVE_OPTIMIZATIONS_PER_TRACE = 4  # maximum number of adaptive optimizations we will do for each function (this can be 2 adaptive optimizations for 2 candidates for example)
+# MAX_ADAPTIVE_OPTIMIZATIONS_PER_TRACE = 4  # maximum number of adaptive optimizations we will do for each function (this can be 2 adaptive optimizations for 2 candidates for example)
+MAX_ADAPTIVE_OPTIMIZATIONS_PER_TRACE = (
+    0  # disable adaptive optimizations until we have this value controlled by the effort arg
+)
 
 MAX_N_CANDIDATES = 5
 MAX_N_CANDIDATES_LP = 6


### PR DESCRIPTION
having adaptive optimization enabled will take time generating and testing more candidates, which is not suitable for low effort like vscode.