### PR TITLE
FIX: Windows bug during remove worktree permission error

### DIFF
--- a/codeflash/code_utils/git_worktree_utils.py
+++ b/codeflash/code_utils/git_worktree_utils.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import configparser
-import os
 import shutil
 import stat
 import subprocess
 import tempfile
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Callable, Optional
 
 import git
 
@@ -98,10 +97,12 @@ def create_detached_worktree(module_root: Path) -> Optional[Path]:
         return worktree_dir
 
 
-def _handle_remove_readonly(func, path, exc_info):
+def _handle_remove_readonly(
+    func: Callable[[str], None], path: str, exc_info: tuple[type[BaseException], BaseException, Any]
+) -> None:
     """Error handler for shutil.rmtree to handle read-only files on Windows."""
     if isinstance(exc_info[1], PermissionError):
-        os.chmod(path, stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR)
+        Path(path).chmod(stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR)
         func(path)
     else:
         raise exc_info[1]


### PR DESCRIPTION
## Fix: Handle Windows permission errors when removing git worktrees

This PR fixes permission errors when removing git worktrees on Windows. The branch includes two commits that take different approaches.

### Problem
On Windows, `git worktree remove --force` can fail with:
- Permission denied errors (files locked by processes)
- "not a git repository" errors (corrupted/partially created worktrees)

### Solution Overview

This PR contains two commits with different approaches:

#### Commit 1: `6bda38e8` - Retry + fallback approach
- Tries `git worktree remove --force` first
- Retries once with a 0.5s delay on permission errors
- Falls back to `shutil.rmtree(ignore_errors=True)` if git commands fail
- Attempts `git worktree prune` to clean up git's internal list
- Handles both `InvalidGitRepositoryError` and `GitCommandError`
- ~55 lines of code with multiple exception handlers

#### Commit 2: `c382f1965` - Direct deletion approach (current)
- Skips git commands entirely
- Directly uses `shutil.rmtree` with an `onerror` callback
- Properly handles Windows read-only files via `os.chmod` before deletion
- ~18 lines of code, single exception handler
- No retry delays or git operations

### Differences

| Aspect | Commit 1 (Retry approach) | Commit 2 (Direct approach) |
|--------|---------------------------|----------------------------|
| **Complexity** | Higher (~55 lines) | Lower (~18 lines) |
| **Git operations** | Uses `git worktree remove` + `prune` | None |
| **Retry logic** | Yes (0.5s delay) | No |
| **Read-only files** | `ignore_errors=True` (silent) | Proper `os.chmod` handling |
| **Git repo required** | Yes (can fail) | No |
| **Worktree list cleanup** | Explicit `git worktree prune` | Relies on auto-prune |

### Trade-offs

**Commit 1 (Retry approach):**
- ✅ Explicitly cleans up git's worktree list
- ❌ More complex, requires valid git repo
- ❌ Retry delays add latency
- ❌ `ignore_errors=True` may hide real issues

**Commit 2 (Direct approach):**
- ✅ Simpler, fewer failure points
- ✅ No git operations needed
- ✅ Properly handles read-only files
- ❌ Stale worktree entries remain (harmless, auto-pruned later)



@mohammedahmed18 @Saga4 Please review both commits and indicate which approach you prefer. If you prefer Commit 1, we can revert Commit 2. If you prefer Commit 2, we can approve and merge directly.
