### PR TITLE
[FIX] correctly detect codeflash import

### DIFF
--- a/codeflash/languages/javascript/instrument.py
+++ b/codeflash/languages/javascript/instrument.py
@@ -51,6 +51,11 @@ class StandaloneCallMatch:
     has_trailing_semicolon: bool
 
 
+codeflash_import_pattern = re.compile(
+    r"(import\s+codeflash\s+from\s+['\"]codeflash['\"])|(const\s+codeflash\s*=\s*require\(['\"]codeflash['\"]\))"
+)
+
+
 class StandaloneCallTransformer:
     """Transforms standalone func(...) calls in JavaScript test code.
 
@@ -730,7 +735,7 @@ def _instrument_js_test_code(
     """
     # Add codeflash helper import if not already present
     # Support both npm package (codeflash) and legacy local file (codeflash-jest-helper)
-    has_codeflash_import = "codeflash" in code
+    has_codeflash_import = codeflash_import_pattern.search(code)
     if not has_codeflash_import:
         # Detect module system: ESM uses "import ... from", CommonJS uses "require()"
         is_esm = bool(re.search(r"^\s*import\s+.+\s+from\s+['\"]", code, re.MULTILINE))


### PR DESCRIPTION
this fixes the issue where codeflash import is not added because the generated test has the word codeflash

```bash

    ReferenceError: codeflash is not defined

      302 |       }
      303 |
    > 304 |       const result = await codeflash.capture('PlainTextStagingStrategy.save', '8', PlainTextStagingStrategy.save.bind(PlainTextStagingStrategy), context)
          |                      ^
      305 |
      306 |       expect(result).toEqual({ success: true, storageType: 'plain_text' })
      307 |       expect(mockedFindFirst).toHaveBeenCalledTimes(1)

```