### PR TITLE
fix: detect test directories inside module_root for JS/TS projects

### DIFF
--- a/codeflash/cli_cmds/cli.py
+++ b/codeflash/cli_cmds/cli.py
@@ -212,11 +212,22 @@ def process_pyproject_config(args: Namespace) -> Namespace:
     is_js_ts_project = pyproject_config.get("language") in ("javascript", "typescript")
     if args.tests_root is None:
         if is_js_ts_project:
-            # Try common JS test directories, or default to module_root
+            # Try common JS test directories at project root first
             for test_dir in ["test", "tests", "__tests__"]:
                 if Path(test_dir).is_dir():
                     args.tests_root = test_dir
                     break
+            # If not found at project root, try inside module_root (e.g., src/test, src/__tests__)
+            if args.tests_root is None and args.module_root:
+                module_root_path = Path(args.module_root)
+                for test_dir in ["test", "tests", "__tests__"]:
+                    test_path = module_root_path / test_dir
+                    if test_path.is_dir():
+                        args.tests_root = str(test_path)
+                        break
+            # Final fallback: default to module_root
+            # Note: This may cause issues if tests are colocated with source files
+            # In such cases, the user should explicitly configure testsRoot in package.json
             if args.tests_root is None:
                 args.tests_root = args.module_root
         else:


### PR DESCRIPTION
## Summary

Fixes an issue where JavaScript/TypeScript projects with test directories inside the module root (e.g., `src/test/`) would have ALL source functions incorrectly filtered out as "test functions" during discovery.

**Root cause:** When `tests_root` is not explicitly configured, the CLI was only looking for test directories at the project root level (`test/`, `tests/`, `__tests__/`). If none were found, it would default `tests_root` to the same value as `module_root`. This caused the filter logic in `functions_to_optimize.py` to treat ALL files under `module_root` as test files.

**The fix:** The CLI now searches for test directories in this order:
1. Project root level: `test/`, `tests/`, `__tests__/`
2. Inside module_root: `{module_root}/test/`, `{module_root}/tests/`, `{module_root}/__tests__/`
3. Fallback to `module_root` (with a comment noting the user should configure `testsRoot` explicitly)

## Example

For a project with:
```
my-app/
├── package.json
└── src/
    ├── index.ts
    ├── utils/
    │   └── helpers.ts
    └── test/
        └── helpers.test.ts
```

**Before this fix:**
- `module_root` = `src/`
- `tests_root` = `src/` (incorrect - same as module_root!)
- Result: ALL functions in `src/` were filtered as "test functions" → "Found 0 functions to optimize"

**After this fix:**
- `module_root` = `src/`
- `tests_root` = `src/test/` (correct!)
- Result: Only files in `src/test/` are filtered → Functions in `src/utils/` etc. are optimized

## Test plan

- [x] Tested on Appsmith's RTS package which has tests at `src/test/`
- [x] Before fix: "Found 0 functions to optimize" (53 functions incorrectly filtered as tests)
- [x] After fix: Functions are discovered and optimization candidates are generated

🤖 Generated with [Claude Code](https://claude.ai/claude-code)