### PR TITLE
fix: filter out test diffs with None test_src_code

### DIFF
--- a/codeflash/api/aiservice.py
+++ b/codeflash/api/aiservice.py
@@ -484,12 +484,17 @@ class AiServiceClient:
         """
         console.rule()
         try:
+            # Filter out test diffs where test_src_code is None since aiservice requires it to be a string
+            valid_test_diffs = [diff for diff in request.test_diffs if diff.test_src_code is not None]
+            if not valid_test_diffs:
+                logger.warning("No test diffs with valid test_src_code found, skipping code repair")
+                return None
             payload = {
                 "optimization_id": request.optimization_id,
                 "original_source_code": request.original_source_code,
                 "modified_source_code": request.modified_source_code,
                 "trace_id": request.trace_id,
-                "test_diffs": request.test_diffs,
+                "test_diffs": valid_test_diffs,
                 "language": request.language,
             }
             response = self.make_ai_service_request("/code_repair", payload=payload, timeout=self.timeout)


### PR DESCRIPTION
## Summary
- Filter out test diffs where `test_src_code` is `None` before calling the code_repair API endpoint
- Return early with a warning log if no valid test diffs remain after filtering

## Problem
When running codeflash on JavaScript/TypeScript files, the code_repair API call fails with:
```
ERROR    Error generating optimized candidates: 422 - {"detail": [{"type":      
         "string_type", "loc": ["body", "data", "test_diffs", 0,                
         "test_src_code"], "msg": "Input should be a valid string"}]}
```

This happens because:
1. The CLI's `TestDiff.test_src_code` is `Optional[str] = None`
2. The `get_src_code()` method returns `None` when it can't find/parse the test source
3. The aiservice expects `test_src_code: str` (non-nullable)

## Test plan
- [x] Manual testing with codeflash on appsmith TypeScript codebase
- [x] Unit test to verify filtering logic works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)