### PR TITLE
fix: revert code after PR creation in --file --function mode

### DIFF
--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -2256,7 +2256,7 @@ class FunctionOptimizer:
             self.args.all
             or env_utils.get_pr_number()
             or self.args.replay_test
-            or (self.args.file and not self.args.function)
+            or self.args.file  # Always revert when using --file mode (with or without --function)
         ):
             self.revert_code_and_helpers(original_helper_code)
             return


### PR DESCRIPTION
## Summary
- Fix code not being reverted after PR creation when using `--file --function` mode
- Affects both Python and JavaScript/TypeScript optimizations

## Problem
When running codeflash with both `--file` and `--function` flags:
```bash
codeflash --file src/utils/DynamicBindingUtils.ts --function getEntityName
```

The optimized code was **not reverted** after PR creation. This caused subsequent optimizations to accumulate in the working directory, resulting in PRs that contained multiple unrelated optimizations.

For example, PR #11 in codeflash-ai/appsmith contained optimizations from PRs #5, #6, #7, #8, #9, and #10 instead of just the `getEntityName` optimization.

## Root Cause
The bug was in line 2259 of `function_optimizer.py`:
```python
or (self.args.file and not self.args.function)
```

This condition is `False` when both `--file` AND `--function` are set, so the code never enters the revert block.

## Fix
Changed to:
```python
or self.args.file  # Always revert when using --file mode (with or without --function)
```

This correctly reverts the code after PR creation regardless of whether `--function` is also specified.

## Test plan
- [x] Manual testing: run `codeflash --file <file> --function <func>` twice and verify second PR only contains the new optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)