### PR TITLE
fix: prevent type definitions from being duplicated in optimized code

### DIFF
--- a/codeflash/context/code_context_extractor.py
+++ b/codeflash/context/code_context_extractor.py
@@ -350,8 +350,9 @@ def get_code_optimization_context_for_language(
     return CodeOptimizationContext(
         testgen_context=testgen_context,
         read_writable_code=read_writable_code,
-        # Global variables are now included in read-writable code, so don't duplicate in read-only
-        read_only_context_code="",
+        # Type definitions are provided as read-only context (not part of code to be replaced)
+        # This prevents AI from duplicating imported types in the optimized output
+        read_only_context_code=code_context.type_definitions_context,
         hashing_code_context=read_writable_code.flat,
         hashing_code_context_hash=code_hash,
         helper_functions=helper_function_sources,

--- a/codeflash/languages/base.py
+++ b/codeflash/languages/base.py
@@ -145,7 +145,8 @@ class CodeContext:
         target_code: Source code of the function to optimize.
         target_file: Path to the file containing the target function.
         helper_functions: List of helper functions called by the target.
-        read_only_context: Additional context code (read-only dependencies).
+        read_only_context: Module-level global variables that may be modified.
+        type_definitions_context: Type/interface definitions for context only (not to be modified).
         imports: List of import statements needed.
         language: The programming language.
 
@@ -155,6 +156,7 @@ class CodeContext:
     target_file: Path
     helper_functions: list[HelperFunction] = field(default_factory=list)
     read_only_context: str = ""
+    type_definitions_context: str = ""
     imports: list[str] = field(default_factory=list)
     language: Language = Language.PYTHON
 

--- a/codeflash/languages/javascript/support.py
+++ b/codeflash/languages/javascript/support.py
@@ -384,12 +384,9 @@ class JavaScriptSupport:
             exclude_names=type_definition_names,
         )
 
-        # Combine type definitions with other read-only context
-        if type_definitions_context:
-            if read_only_context:
-                read_only_context = type_definitions_context + "\n\n" + read_only_context
-            else:
-                read_only_context = type_definitions_context
+        # Keep type definitions separate from global variables
+        # Type definitions should be provided as true read-only context (not part of code to be replaced)
+        # Global variables may need to be modified and are included in the read-writable context
 
         # Validate that the extracted code is syntactically valid
         # If not, raise an error to fail the optimization early
@@ -406,6 +403,7 @@ class JavaScriptSupport:
             target_file=function.file_path,
             helper_functions=helpers,
             read_only_context=read_only_context,
+            type_definitions_context=type_definitions_context,
             imports=import_lines,
             language=Language.JAVASCRIPT,
         )


### PR DESCRIPTION
## Summary

- Fix bug where type definitions (interfaces, types) were being duplicated in the optimized output
- Type definitions that are imported in the original file were incorrectly being included in the code sent to the AI for optimization
- When the AI returned the optimized code, it included these type definitions, causing duplicates

## Root Cause

Type definitions extracted during context extraction were being combined with `read_only_context`, which gets prepended to the target code and becomes part of the "read-writable" code to be replaced. This caused the AI to see the type definitions as part of the code it should return, duplicating imported types.

## Fix

- Add `type_definitions_context` field to `CodeContext` to keep type definitions separate from global variables
- Pass type definitions as `read_only_context_code` to the optimizer (true read-only context that is NOT part of the code to be replaced)
- Global variables (which may need to be modified) remain in `read_only_context` and are prepended to target code

## Test plan

- [x] Added unit tests that verify type definitions are in `type_definitions_context`, not `read_only_context`
- [x] Added integration test that verifies type definitions are passed as `read_only_context_code` to the optimizer
- [x] All 56 JavaScript support tests pass
- [x] All 81 code context extractor tests pass

## Related

Fixes the bug in https://github.com/codeflash-ai/appsmith/pull/20 where `TreeNode` interface was duplicated in the optimization output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)