### PR TITLE
Fix require() inside functions being treated as imports

### DIFF
--- a/codeflash/languages/treesitter_utils.py
+++ b/codeflash/languages/treesitter_utils.py
@@ -454,23 +454,46 @@ class TreeSitterAnalyzer:
 
         return imports
 
-    def _walk_tree_for_imports(self, node: Node, source_bytes: bytes, imports: list[ImportInfo]) -> None:
-        """Recursively walk the tree to find import statements."""
+    def _walk_tree_for_imports(
+        self, node: Node, source_bytes: bytes, imports: list[ImportInfo], in_function: bool = False
+    ) -> None:
+        """Recursively walk the tree to find import statements.
+
+        Args:
+            node: Current node to check.
+            source_bytes: Source code bytes.
+            imports: List to append found imports to.
+            in_function: Whether we're currently inside a function/method body.
+        """
+        # Track when we enter function/method bodies
+        # These node types contain function/method bodies where require() should not be treated as imports
+        function_body_types = {
+            "function_declaration",
+            "method_definition",
+            "arrow_function",
+            "function_expression",
+            "function",  # Generic function in some grammars
+        }
+
         if node.type == "import_statement":
             import_info = self._extract_import_info(node, source_bytes)
             if import_info:
                 imports.append(import_info)
 
-        # Also handle require() calls for CommonJS
-        if node.type == "call_expression":
+        # Also handle require() calls for CommonJS, but only at module level
+        # require() inside functions is a dynamic import, not a module import
+        if node.type == "call_expression" and not in_function:
             func_node = node.child_by_field_name("function")
             if func_node and self.get_node_text(func_node, source_bytes) == "require":
                 import_info = self._extract_require_info(node, source_bytes)
                 if import_info:
                     imports.append(import_info)
 
+        # Update in_function flag for children
+        child_in_function = in_function or node.type in function_body_types
+
         for child in node.children:
-            self._walk_tree_for_imports(child, source_bytes, imports)
+            self._walk_tree_for_imports(child, source_bytes, imports, child_in_function)
 
     def _extract_import_info(self, node: Node, source_bytes: bytes) -> ImportInfo | None:
         """Extract import information from an import statement node."""

--- a/tests/test_languages/test_treesitter_utils.py
+++ b/tests/test_languages/test_treesitter_utils.py
@@ -351,6 +351,32 @@ class TestFindImports:
         assert imports[0].module_path == "fs"
         assert imports[0].default_import == "fs"
 
+    def test_require_inside_function_not_import(self, js_analyzer):
+        """Test that require() inside functions is not treated as an import.
+
+        This is important because dynamic require() calls inside functions are
+        not module-level imports and should not be extracted as such.
+        """
+        code = """
+const fs = require('fs');
+
+function loadModule() {
+    const dynamic = require('dynamic-module');
+    return dynamic;
+}
+
+class MyClass {
+    method() {
+        const inMethod = require('method-module');
+    }
+}
+"""
+        imports = js_analyzer.find_imports(code)
+
+        # Only the module-level require should be found
+        assert len(imports) == 1
+        assert imports[0].module_path == "fs"
+
     def test_find_multiple_imports(self, js_analyzer):
         """Test finding multiple imports."""
         code = """


### PR DESCRIPTION
## Summary

- Fixed a bug where dynamic `require()` calls inside function/method bodies were incorrectly treated as module-level imports
- This caused invalid code to be sent to the AI service, resulting in "Invalid TypeScript: Invalid syntax" errors
- Root cause: the tree traversal for finding imports didn't exclude function bodies

## Example

The code:
```typescript
class BloomFilter {
    export() {
        const gzipSize = (
            require('next/dist/compiled/gzip-size') as typeof import('next/dist/compiled/gzip-size')
        ).sync(filterData)
    }
}
```

Would incorrectly extract `require('next/dist/compiled/gzip-size') as typeof import('next/dist/compiled/gzip-size')` as an import, which when added to the top of the file creates invalid syntax.

## Test plan

- [x] Added test `test_require_inside_function_not_import`
- [x] All 44 existing treesitter_utils tests pass
- [x] Verified that the bloom-filter.ts export method no longer causes invalid syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)