### PR TITLE
pnpm package manager support for jS/ts

### DIFF
--- a/codeflash/cli_cmds/init_javascript.py
+++ b/codeflash/cli_cmds/init_javascript.py
@@ -136,6 +136,43 @@ def determine_js_package_manager(project_root: Path) -> JsPackageManager:
     return JsPackageManager.UNKNOWN
 
 
+def get_package_install_command(project_root: Path, package: str, dev: bool = True) -> list[str]:
+    """Get the correct install command for the project's package manager.
+
+    Args:
+        project_root: The project root directory.
+        package: The package name to install.
+        dev: Whether to install as a dev dependency (default: True).
+
+    Returns:
+        List of command arguments for subprocess execution.
+
+    """
+    pkg_manager = determine_js_package_manager(project_root)
+
+    if pkg_manager == JsPackageManager.PNPM:
+        cmd = ["pnpm", "add", package]
+        if dev:
+            cmd.append("--save-dev")
+        return cmd
+    elif pkg_manager == JsPackageManager.YARN:
+        cmd = ["yarn", "add", package]
+        if dev:
+            cmd.append("--dev")
+        return cmd
+    elif pkg_manager == JsPackageManager.BUN:
+        cmd = ["bun", "add", package]
+        if dev:
+            cmd.append("--dev")
+        return cmd
+    else:
+        # Default to npm
+        cmd = ["npm", "install", package]
+        if dev:
+            cmd.append("--save-dev")
+        return cmd
+
+
 def init_js_project(language: ProjectLanguage) -> None:
     """Initialize Codeflash for a JavaScript/TypeScript project."""
     from codeflash.cli_cmds.cmd_init import install_github_actions, install_github_app, prompt_api_key

--- a/codeflash/languages/javascript/test_runner.py
+++ b/codeflash/languages/javascript/test_runner.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from codeflash.cli_cmds.console import logger
+from codeflash.cli_cmds.init_javascript import get_package_install_command
 from codeflash.code_utils.code_utils import get_run_tmp_file
 from codeflash.code_utils.config_consts import STABILITY_CENTER_TOLERANCE, STABILITY_SPREAD_TOLERANCE
 from codeflash.code_utils.shell_utils import get_cross_platform_subprocess_run_args
@@ -145,6 +146,7 @@ def _ensure_runtime_files(project_root: Path) -> None:
 
     Installs codeflash package if not already present.
     The package provides all runtime files needed for test instrumentation.
+    Uses the project's detected package manager (npm, pnpm, yarn, or bun).
 
     Args:
         project_root: The project root directory.
@@ -155,9 +157,10 @@ def _ensure_runtime_files(project_root: Path) -> None:
         logger.debug("codeflash already installed")
         return
 
+    install_cmd = get_package_install_command(project_root, "codeflash", dev=True)
     try:
         result = subprocess.run(
-            ["npm", "install", "--save-dev", "codeflash"],
+            install_cmd,
             check=False,
             cwd=project_root,
             capture_output=True,
@@ -165,13 +168,13 @@ def _ensure_runtime_files(project_root: Path) -> None:
             timeout=120,
         )
         if result.returncode == 0:
-            logger.debug("Installed codeflash from npm registry")
+            logger.debug(f"Installed codeflash using {install_cmd[0]}")
             return
-        logger.warning(f"Failed to install from npm: {result.stderr}")
+        logger.warning(f"Failed to install codeflash: {result.stderr}")
     except Exception as e:
-        logger.warning(f"Error installing from npm: {e}")
+        logger.warning(f"Error installing codeflash: {e}")
 
-    logger.error("Could not install codeflash. Please install it manually: npm install --save-dev codeflash")
+    logger.error(f"Could not install codeflash. Please install it manually: {' '.join(install_cmd)}")
 
 
 def run_jest_behavioral_tests(

--- a/tests/test_init_javascript.py
+++ b/tests/test_init_javascript.py
@@ -1,0 +1,192 @@
+"""Tests for JavaScript/TypeScript project initialization and package manager detection."""
+
+from pathlib import Path
+
+import pytest
+
+from codeflash.cli_cmds.init_javascript import (
+    JsPackageManager,
+    determine_js_package_manager,
+    get_package_install_command,
+)
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    """Create a temporary project directory."""
+    return tmp_path
+
+
+class TestDetermineJsPackageManager:
+    """Tests for determine_js_package_manager function."""
+
+    def test_detects_pnpm_from_lockfile(self, tmp_project: Path) -> None:
+        """Should detect pnpm from pnpm-lock.yaml."""
+        (tmp_project / "pnpm-lock.yaml").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.PNPM
+
+    def test_detects_yarn_from_lockfile(self, tmp_project: Path) -> None:
+        """Should detect yarn from yarn.lock."""
+        (tmp_project / "yarn.lock").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.YARN
+
+    def test_detects_npm_from_lockfile(self, tmp_project: Path) -> None:
+        """Should detect npm from package-lock.json."""
+        (tmp_project / "package-lock.json").write_text("{}")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.NPM
+
+    def test_detects_bun_from_lockfile(self, tmp_project: Path) -> None:
+        """Should detect bun from bun.lockb."""
+        (tmp_project / "bun.lockb").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.BUN
+
+    def test_detects_bun_from_bun_lock(self, tmp_project: Path) -> None:
+        """Should detect bun from bun.lock."""
+        (tmp_project / "bun.lock").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.BUN
+
+    def test_defaults_to_npm_with_package_json_only(self, tmp_project: Path) -> None:
+        """Should default to npm when only package.json exists."""
+        (tmp_project / "package.json").write_text("{}")
+
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.NPM
+
+    def test_returns_unknown_without_package_json(self, tmp_project: Path) -> None:
+        """Should return UNKNOWN when no package.json exists."""
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.UNKNOWN
+
+    def test_pnpm_takes_precedence_over_npm(self, tmp_project: Path) -> None:
+        """Should prefer pnpm when both lockfiles exist (migration scenario)."""
+        (tmp_project / "pnpm-lock.yaml").write_text("")
+        (tmp_project / "package-lock.json").write_text("{}")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.PNPM
+
+    def test_bun_takes_precedence_over_others(self, tmp_project: Path) -> None:
+        """Should prefer bun when bun.lockb exists alongside others."""
+        (tmp_project / "bun.lockb").write_text("")
+        (tmp_project / "pnpm-lock.yaml").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = determine_js_package_manager(tmp_project)
+
+        assert result == JsPackageManager.BUN
+
+
+class TestGetPackageInstallCommand:
+    """Tests for get_package_install_command function."""
+
+    def test_npm_install_command(self, tmp_project: Path) -> None:
+        """Should return npm install command for npm projects."""
+        (tmp_project / "package-lock.json").write_text("{}")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "codeflash", dev=True)
+
+        assert result == ["npm", "install", "codeflash", "--save-dev"]
+
+    def test_npm_install_command_non_dev(self, tmp_project: Path) -> None:
+        """Should return npm install command without --save-dev when dev=False."""
+        (tmp_project / "package-lock.json").write_text("{}")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "codeflash", dev=False)
+
+        assert result == ["npm", "install", "codeflash"]
+
+    def test_pnpm_add_command(self, tmp_project: Path) -> None:
+        """Should return pnpm add command for pnpm projects."""
+        (tmp_project / "pnpm-lock.yaml").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "codeflash", dev=True)
+
+        assert result == ["pnpm", "add", "codeflash", "--save-dev"]
+
+    def test_pnpm_add_command_non_dev(self, tmp_project: Path) -> None:
+        """Should return pnpm add command without --save-dev when dev=False."""
+        (tmp_project / "pnpm-lock.yaml").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "codeflash", dev=False)
+
+        assert result == ["pnpm", "add", "codeflash"]
+
+    def test_yarn_add_command(self, tmp_project: Path) -> None:
+        """Should return yarn add command for yarn projects."""
+        (tmp_project / "yarn.lock").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "codeflash", dev=True)
+
+        assert result == ["yarn", "add", "codeflash", "--dev"]
+
+    def test_yarn_add_command_non_dev(self, tmp_project: Path) -> None:
+        """Should return yarn add command without --dev when dev=False."""
+        (tmp_project / "yarn.lock").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "codeflash", dev=False)
+
+        assert result == ["yarn", "add", "codeflash"]
+
+    def test_bun_add_command(self, tmp_project: Path) -> None:
+        """Should return bun add command for bun projects."""
+        (tmp_project / "bun.lockb").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "codeflash", dev=True)
+
+        assert result == ["bun", "add", "codeflash", "--dev"]
+
+    def test_bun_add_command_non_dev(self, tmp_project: Path) -> None:
+        """Should return bun add command without --dev when dev=False."""
+        (tmp_project / "bun.lockb").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "codeflash", dev=False)
+
+        assert result == ["bun", "add", "codeflash"]
+
+    def test_defaults_to_npm_for_unknown(self, tmp_project: Path) -> None:
+        """Should default to npm for unknown package manager."""
+        # No lockfile, no package.json - unknown package manager
+        result = get_package_install_command(tmp_project, "codeflash", dev=True)
+
+        assert result == ["npm", "install", "codeflash", "--save-dev"]
+
+    def test_different_package_name(self, tmp_project: Path) -> None:
+        """Should work with different package names."""
+        (tmp_project / "pnpm-lock.yaml").write_text("")
+        (tmp_project / "package.json").write_text("{}")
+
+        result = get_package_install_command(tmp_project, "typescript", dev=True)
+
+        assert result == ["pnpm", "add", "typescript", "--save-dev"]


### PR DESCRIPTION
Fix: Use detected package manager for installing codeflash npm package                                                           
  - Previously, always used `npm install` which fails for pnpm/yarn/bun projects                                                     
  - Now automatically detects and uses the correct package manager             