### PR TITLE
feat: include package in Java function qualified names

### DIFF
--- a/codeflash/languages/java/discovery.py
+++ b/codeflash/languages/java/discovery.py
@@ -82,6 +82,9 @@ def discover_functions_from_source(
             include_static=True,
         )
 
+        # Extract package name for qualified names
+        package_name = analyzer.get_package_name(source)
+
         functions: list[FunctionInfo] = []
 
         for method in methods:
@@ -89,8 +92,10 @@ def discover_functions_from_source(
             if not _should_include_method(method, criteria, source, analyzer):
                 continue
 
-            # Build parents list
+            # Build parents list - include package for fully qualified names
             parents: list[ParentInfo] = []
+            if package_name:
+                parents.append(ParentInfo(name=package_name, type="package"))
             if method.class_name:
                 parents.append(ParentInfo(name=method.class_name, type="ClassDef"))
 


### PR DESCRIPTION
## Summary
- Java function qualified names now include the package prefix
- Ensures consistent fully-qualified naming for Java functions in markdown output and PR descriptions

## Problem
When codeflash generates PR descriptions or explanations, Java functions appeared as:
- `Calculator.fibonacci` instead of `com.example.Calculator.fibonacci`

This made function references ambiguous, especially in large projects with multiple classes having the same name in different packages.

## Solution
Include the package in the `parents` tuple when discovering Java functions:
- Package (type="package") - e.g., "com.example"
- Class (type="ClassDef") - e.g., "Calculator"

The `qualified_name` property automatically builds the full path from parents.

### Before
```
Buffer.bytesToHexString
```

### After
```
com.aerospike.client.command.Buffer.bytesToHexString
```

## Test plan
- [x] Added `TestQualifiedNameWithPackage` test class with 4 test cases:
  - `test_qualified_name_includes_package` - basic package inclusion
  - `test_qualified_name_with_nested_package` - deeply nested packages
  - `test_qualified_name_without_package` - default package behavior preserved
  - `test_parents_include_package_and_class` - verify parent structure
- [x] All existing discovery tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)