### PR TITLE
Fix Java test path duplication when tests_root includes package path

### DIFF
--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -657,6 +657,47 @@ class FunctionOptimizer:
             )
         )
 
+    def _get_java_sources_root(self) -> Path:
+        """Get the Java sources root directory for test files.
+
+        For Java projects, tests_root might include the package path
+        (e.g., test/src/com/aerospike/test). We need to find the base directory
+        that should contain the package directories, not the tests_root itself.
+
+        This method looks for standard Java package prefixes (com, org, net, io, edu, gov)
+        in the tests_root path and returns everything before that prefix.
+
+        Returns:
+            Path to the Java sources root directory.
+
+        """
+        tests_root = self.test_cfg.tests_root
+        parts = tests_root.parts
+
+        # Look for standard Java package prefixes that indicate the start of package structure
+        standard_package_prefixes = ('com', 'org', 'net', 'io', 'edu', 'gov')
+
+        for i, part in enumerate(parts):
+            if part in standard_package_prefixes:
+                # Found start of package path, return everything before it
+                if i > 0:
+                    java_sources_root = Path(*parts[:i])
+                    logger.debug(f"[JAVA] Detected Java sources root: {java_sources_root} (from tests_root: {tests_root})")
+                    return java_sources_root
+
+        # If no standard package prefix found, check if there's a 'java' directory
+        # (standard Maven structure: src/test/java)
+        for i, part in enumerate(parts):
+            if part == 'java' and i > 0:
+                # Return up to and including 'java'
+                java_sources_root = Path(*parts[:i + 1])
+                logger.debug(f"[JAVA] Detected Maven-style Java sources root: {java_sources_root}")
+                return java_sources_root
+
+        # Default: return tests_root as-is (original behavior)
+        logger.debug(f"[JAVA] Using tests_root as Java sources root: {tests_root}")
+        return tests_root
+
     def _fix_java_test_paths(
         self, behavior_source: str, perf_source: str, used_paths: set[Path]
     ) -> tuple[Path, Path, str, str]:
@@ -693,7 +734,9 @@ class FunctionOptimizer:
         perf_class = perf_class_match.group(1) if perf_class_match else "GeneratedPerfTest"
 
         # Build paths with package structure
-        test_dir = self.test_cfg.tests_root
+        # Use the Java sources root, not tests_root, to avoid path duplication
+        # when tests_root already includes the package path
+        test_dir = self._get_java_sources_root()
 
         if package_name:
             package_path = package_name.replace(".", "/")

--- a/tests/test_languages/test_java/test_java_test_paths.py
+++ b/tests/test_languages/test_java/test_java_test_paths.py
@@ -1,0 +1,170 @@
+"""Tests for Java test path handling in FunctionOptimizer."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestGetJavaSourcesRoot:
+    """Tests for the _get_java_sources_root method."""
+
+    def _create_mock_optimizer(self, tests_root: str):
+        """Create a mock FunctionOptimizer with the given tests_root."""
+        from codeflash.optimization.function_optimizer import FunctionOptimizer
+
+        # Create a minimal mock
+        mock_optimizer = MagicMock(spec=FunctionOptimizer)
+        mock_optimizer.test_cfg = MagicMock()
+        mock_optimizer.test_cfg.tests_root = Path(tests_root)
+
+        # Bind the actual method to the mock
+        mock_optimizer._get_java_sources_root = lambda: FunctionOptimizer._get_java_sources_root(mock_optimizer)
+
+        return mock_optimizer
+
+    def test_detects_com_package_prefix(self):
+        """Test that it correctly detects 'com' package prefix and returns parent."""
+        optimizer = self._create_mock_optimizer("/project/test/src/com/aerospike/test")
+        result = optimizer._get_java_sources_root()
+        assert result == Path("/project/test/src")
+
+    def test_detects_org_package_prefix(self):
+        """Test that it correctly detects 'org' package prefix and returns parent."""
+        optimizer = self._create_mock_optimizer("/project/src/test/org/example/tests")
+        result = optimizer._get_java_sources_root()
+        assert result == Path("/project/src/test")
+
+    def test_detects_net_package_prefix(self):
+        """Test that it correctly detects 'net' package prefix."""
+        optimizer = self._create_mock_optimizer("/project/test/net/company/utils")
+        result = optimizer._get_java_sources_root()
+        assert result == Path("/project/test")
+
+    def test_detects_io_package_prefix(self):
+        """Test that it correctly detects 'io' package prefix."""
+        optimizer = self._create_mock_optimizer("/project/src/test/java/io/github/project")
+        result = optimizer._get_java_sources_root()
+        assert result == Path("/project/src/test/java")
+
+    def test_detects_edu_package_prefix(self):
+        """Test that it correctly detects 'edu' package prefix."""
+        optimizer = self._create_mock_optimizer("/project/test/edu/university/cs")
+        result = optimizer._get_java_sources_root()
+        assert result == Path("/project/test")
+
+    def test_detects_gov_package_prefix(self):
+        """Test that it correctly detects 'gov' package prefix."""
+        optimizer = self._create_mock_optimizer("/project/test/gov/agency/tools")
+        result = optimizer._get_java_sources_root()
+        assert result == Path("/project/test")
+
+    def test_maven_structure_with_java_dir(self):
+        """Test standard Maven structure: src/test/java."""
+        optimizer = self._create_mock_optimizer("/project/src/test/java")
+        result = optimizer._get_java_sources_root()
+        # Should return the path including 'java'
+        assert result == Path("/project/src/test/java")
+
+    def test_fallback_when_no_package_prefix(self):
+        """Test fallback behavior when no standard package prefix found."""
+        optimizer = self._create_mock_optimizer("/project/custom/tests")
+        result = optimizer._get_java_sources_root()
+        # Should return tests_root as-is
+        assert result == Path("/project/custom/tests")
+
+    def test_relative_path_with_com_prefix(self):
+        """Test with relative path containing 'com' prefix."""
+        optimizer = self._create_mock_optimizer("test/src/com/example")
+        result = optimizer._get_java_sources_root()
+        assert result == Path("test/src")
+
+    def test_aerospike_project_structure(self):
+        """Test with the actual aerospike project structure that had the bug."""
+        # This is the actual path from the bug report
+        optimizer = self._create_mock_optimizer("/Users/test/Work/aerospike-client-java/test/src/com/aerospike/test")
+        result = optimizer._get_java_sources_root()
+        assert result == Path("/Users/test/Work/aerospike-client-java/test/src")
+
+
+class TestFixJavaTestPathsIntegration:
+    """Integration tests for _fix_java_test_paths with the path fix."""
+
+    def _create_mock_optimizer(self, tests_root: str):
+        """Create a mock FunctionOptimizer with the given tests_root."""
+        from codeflash.optimization.function_optimizer import FunctionOptimizer
+
+        mock_optimizer = MagicMock(spec=FunctionOptimizer)
+        mock_optimizer.test_cfg = MagicMock()
+        mock_optimizer.test_cfg.tests_root = Path(tests_root)
+
+        # Bind the actual methods
+        mock_optimizer._get_java_sources_root = lambda: FunctionOptimizer._get_java_sources_root(mock_optimizer)
+        mock_optimizer._fix_java_test_paths = lambda behavior_source, perf_source, used_paths: FunctionOptimizer._fix_java_test_paths(mock_optimizer, behavior_source, perf_source, used_paths)
+
+        return mock_optimizer
+
+    def test_no_path_duplication_with_package_in_tests_root(self, tmp_path):
+        """Test that paths are not duplicated when tests_root includes package structure."""
+        # Create a tests_root that includes package path (like aerospike project)
+        tests_root = tmp_path / "test" / "src" / "com" / "aerospike" / "test"
+        tests_root.mkdir(parents=True)
+
+        optimizer = self._create_mock_optimizer(str(tests_root))
+
+        behavior_source = """
+package com.aerospike.client.util;
+
+public class UnpackerTest__perfinstrumented {
+    @Test
+    public void testUnpack() {}
+}
+"""
+        perf_source = """
+package com.aerospike.client.util;
+
+public class UnpackerTest__perfonlyinstrumented {
+    @Test
+    public void testUnpack() {}
+}
+"""
+        behavior_path, perf_path, _, _ = optimizer._fix_java_test_paths(behavior_source, perf_source, set())
+
+        # The path should be test/src/com/aerospike/client/util/UnpackerTest__perfinstrumented.java
+        # NOT test/src/com/aerospike/test/com/aerospike/client/util/...
+        expected_java_root = tmp_path / "test" / "src"
+        assert behavior_path == expected_java_root / "com" / "aerospike" / "client" / "util" / "UnpackerTest__perfinstrumented.java"
+        assert perf_path == expected_java_root / "com" / "aerospike" / "client" / "util" / "UnpackerTest__perfonlyinstrumented.java"
+
+        # Verify there's no duplication in the path
+        assert "com/aerospike/test/com" not in str(behavior_path)
+        assert "com/aerospike/test/com" not in str(perf_path)
+
+    def test_standard_maven_structure(self, tmp_path):
+        """Test with standard Maven structure (src/test/java)."""
+        tests_root = tmp_path / "src" / "test" / "java"
+        tests_root.mkdir(parents=True)
+
+        optimizer = self._create_mock_optimizer(str(tests_root))
+
+        behavior_source = """
+package com.example;
+
+public class CalculatorTest__perfinstrumented {
+    @Test
+    public void testAdd() {}
+}
+"""
+        perf_source = """
+package com.example;
+
+public class CalculatorTest__perfonlyinstrumented {
+    @Test
+    public void testAdd() {}
+}
+"""
+        behavior_path, perf_path, _, _ = optimizer._fix_java_test_paths(behavior_source, perf_source, set())
+
+        # Should be src/test/java/com/example/CalculatorTest__perfinstrumented.java
+        assert behavior_path == tests_root / "com" / "example" / "CalculatorTest__perfinstrumented.java"
+        assert perf_path == tests_root / "com" / "example" / "CalculatorTest__perfonlyinstrumented.java"


### PR DESCRIPTION
Fix Java test path duplication when tests_root includes package path

  Problem

  When running Java optimization with a tests_root that already includes the Java package path (e.g.,
  test/src/com/aerospike/test), generated test files were being written to incorrect duplicated paths:

```  
WARNING  Test type not found for '/Users/.../test/src/com/aerospike/test/SuiteSync.java'.
           Registered test files:
           ['/Users/.../test/src/com/aerospike/test/com/aerospike/client/util/UnpackerTest__perfinstrumented.java',
            '/Users/.../test/src/com/aerospike/test/com/aerospike/client/util/UnpackerTest__perfinstrumented_2.java']
  INFO     Tests '[None, None]' failed to run, skipping
```
  Duplicated path structure: test/src/com/aerospike/test/com/aerospike/client/util/...

  This caused:
  - Test files written to wrong locations
  - original_file_path returning None for generated tests
  - Behavioral tests failing to run with Tests '[None, None]' failed to run

  Root Cause

  In _fix_java_test_paths(), the code used self.test_cfg.tests_root directly and appended the package path from the
  generated test source. When tests_root already contained the package structure (test/src/com/aerospike/test),
  appending the test's package (com.aerospike.client.util) created a duplicated path.

  Solution

  Added _get_java_sources_root() method that:
  1. Detects standard Java package prefixes (com, org, net, io, edu, gov) in tests_root
  2. Returns the base directory before the package structure (e.g., test/src instead of test/src/com/aerospike/test)
  3. Falls back to Maven-style java directory detection
  4. Defaults to original tests_root if no pattern matches

  Result

  Before: test/src/com/aerospike/test/com/aerospike/client/util/UnpackerTest__perfinstrumented.java

  After: test/src/com/aerospike/client/util/UnpackerTest__perfinstrumented.java

