### PR TITLE
fix: prevent false positive test file detection for projects in /tests/ folders

### DIFF
--- a/codeflash/discovery/functions_to_optimize.py
+++ b/codeflash/discovery/functions_to_optimize.py
@@ -839,11 +839,13 @@ def filter_functions(
             if any(pattern in file_lower for pattern in test_file_name_patterns):
                 return True
             # Check directory patterns, but only within the project root
-            # to avoid false positives from parent directories
-            relative_path = file_lower
+            # to avoid false positives from parent directories (e.g., project at /home/user/tests/myproject)
             if project_root_str and file_lower.startswith(project_root_str.lower()):
                 relative_path = file_lower[len(project_root_str) :]
-            return any(pattern in relative_path for pattern in test_dir_patterns)
+                return any(pattern in relative_path for pattern in test_dir_patterns)
+            # If we can't compute relative path from project root, don't check directory patterns
+            # This avoids false positives when project is inside a folder named "tests"
+            return False
         # Use directory-based filtering when tests are in a separate directory
         return file_path_normalized.startswith(tests_root_str + os.sep)
 


### PR DESCRIPTION
## Summary
Fixes incorrect test file filtering when a project is located inside a directory named "tests" (e.g., `/home/user/tests/myproject`).

## Problem
When running codeflash on a project stored in a path containing `/tests/`, source files were incorrectly filtered as test files:

```
Ignored functions and files
└── Test functions removed: 1
INFO     Found 0 function to optimize
```

The issue was in `is_test_file()` which checked for `/tests/` pattern in the **full path** instead of the **relative path from project root**.

## Root Cause
```python
# Before (buggy):
relative_path = file_lower  # Falls back to full path if condition fails
if project_root_str and file_lower.startswith(project_root_str.lower()):
    relative_path = file_lower[len(project_root_str):]
return any(pattern in relative_path for pattern in test_dir_patterns)
```

If the condition failed for any reason, `relative_path` remained the full path, which could contain `/tests/` from parent directories.

## Solution
```python
# After (fixed):
if project_root_str and file_lower.startswith(project_root_str.lower()):
    relative_path = file_lower[len(project_root_str):]
    return any(pattern in relative_path for pattern in test_dir_patterns)
# If we can't compute relative path, don't check directory patterns
return False
```

## Test Results
**Before fix:**
```
Ignored functions and files
└── Test functions removed: 1
INFO     Found 0 function to optimize
```

**After fix:**
- Function is discovered and processed correctly
- Tests are generated
- Optimization proceeds

## Test plan
- [x] Tested on n8n repo at `/Users/saga4/orgs/tests/n8n`
- [x] Function `compareValues` is now discovered (was filtered before)
- [ ] Add unit test for this edge case

Generated with [Claude Code](https://claude.com/claude-code)