### PR TITLE
fix: Use function_name instead of name in Python find_references

### DIFF
--- a/codeflash/languages/python/support.py
+++ b/codeflash/languages/python/support.py
@@ -321,7 +321,7 @@ class PythonSupport:
 
             function_pos = None
             for name in names:
-                if name.type == "function" and name.name == function.name:
+                if name.type == "function" and name.name == function.function_name:
                     # Check for class parent if it's a method
                     if function.class_name:
                         parent = name.parent()


### PR DESCRIPTION
## Summary
- Fix missed attribute rename in `find_references` where `function.name` was used instead of `function.function_name`
- Add tests for `find_references` covering simple functions, class methods, and edge cases

## Test plan
- [x] `pytest tests/test_languages/test_python_support.py -v` passes