### PR TITLE
feat: add gpu flag for CUDA event-based timing

### DIFF
--- a/tests/test_inject_profiling_used_frameworks.py
+++ b/tests/test_inject_profiling_used_frameworks.py
@@ -1492,3 +1492,435 @@ def test_my_function():
         result = normalize_instrumented_code(instrumented_code)
         expected = EXPECTED_ALL_FRAMEWORKS_PERFORMANCE
         assert result == expected
+
+
+# ============================================================================
+# Expected instrumented code for GPU timing mode
+# ============================================================================
+
+EXPECTED_TORCH_GPU_BEHAVIOR = """import gc
+import inspect
+import os
+import sqlite3
+import time
+
+import dill as pickle
+import torch
+from mymodule import my_function
+
+
+def codeflash_wrap(codeflash_wrapped, codeflash_test_module_name, codeflash_test_class_name, codeflash_test_name, codeflash_function_name, codeflash_line_id, codeflash_loop_index, codeflash_cur, codeflash_con, *args, **kwargs):
+    test_id = f'{codeflash_test_module_name}:{codeflash_test_class_name}:{codeflash_test_name}:{codeflash_line_id}:{codeflash_loop_index}'
+    if not hasattr(codeflash_wrap, 'index'):
+        codeflash_wrap.index = {}
+    if test_id in codeflash_wrap.index:
+        codeflash_wrap.index[test_id] += 1
+    else:
+        codeflash_wrap.index[test_id] = 0
+    codeflash_test_index = codeflash_wrap.index[test_id]
+    invocation_id = f'{codeflash_line_id}_{codeflash_test_index}'
+    test_stdout_tag = f'{codeflash_test_module_name}:{(codeflash_test_class_name + '.' if codeflash_test_class_name else '')}{codeflash_test_name}:{codeflash_function_name}:{codeflash_loop_index}:{invocation_id}'
+    print(f'!$######{test_stdout_tag}######$!')
+    exception = None
+    _codeflash_use_gpu_timer = torch.cuda.is_available() and torch.cuda.is_initialized()
+    _codeflash_should_sync_cuda = torch.cuda.is_available() and torch.cuda.is_initialized()
+    _codeflash_should_sync_mps = not _codeflash_should_sync_cuda and hasattr(torch.backends, 'mps') and torch.backends.mps.is_available() and hasattr(torch.mps, 'synchronize')
+    gc.disable()
+    if _codeflash_use_gpu_timer:
+        try:
+            _codeflash_start_event = torch.cuda.Event(enable_timing=True)
+            _codeflash_end_event = torch.cuda.Event(enable_timing=True)
+            _codeflash_start_event.record()
+            return_value = codeflash_wrapped(*args, **kwargs)
+            _codeflash_end_event.record()
+            torch.cuda.synchronize()
+            codeflash_duration = int(_codeflash_start_event.elapsed_time(_codeflash_end_event) * 1000000)
+        except Exception as e:
+            torch.cuda.synchronize()
+            codeflash_duration = 0
+            exception = e
+    else:
+        try:
+            if _codeflash_should_sync_cuda:
+                torch.cuda.synchronize()
+            elif _codeflash_should_sync_mps:
+                torch.mps.synchronize()
+            counter = time.perf_counter_ns()
+            return_value = codeflash_wrapped(*args, **kwargs)
+            if _codeflash_should_sync_cuda:
+                torch.cuda.synchronize()
+            elif _codeflash_should_sync_mps:
+                torch.mps.synchronize()
+            codeflash_duration = time.perf_counter_ns() - counter
+        except Exception as e:
+            codeflash_duration = time.perf_counter_ns() - counter
+            exception = e
+    gc.enable()
+    print(f'!######{test_stdout_tag}######!')
+    pickled_return_value = pickle.dumps(exception) if exception else pickle.dumps(return_value)
+    codeflash_cur.execute('INSERT INTO test_results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)', (codeflash_test_module_name, codeflash_test_class_name, codeflash_test_name, codeflash_function_name, codeflash_loop_index, invocation_id, codeflash_duration, pickled_return_value, 'function_call'))
+    codeflash_con.commit()
+    if exception:
+        raise exception
+    return return_value
+
+def test_my_function():
+    codeflash_loop_index = int(os.environ['CODEFLASH_LOOP_INDEX'])
+    codeflash_iteration = os.environ['CODEFLASH_TEST_ITERATION']
+    codeflash_con = sqlite3.connect(f'{CODEFLASH_DB_PATH}')
+    codeflash_cur = codeflash_con.cursor()
+    codeflash_cur.execute('CREATE TABLE IF NOT EXISTS test_results (test_module_path TEXT, test_class_name TEXT, test_function_name TEXT, function_getting_tested TEXT, loop_index INTEGER, iteration_id TEXT, runtime INTEGER, return_value BLOB, verification_type TEXT)')
+    _call__bound__arguments = inspect.signature(my_function).bind(1, 2)
+    _call__bound__arguments.apply_defaults()
+    result = codeflash_wrap(my_function, 'test_example', None, 'test_my_function', 'my_function', '0', codeflash_loop_index, codeflash_cur, codeflash_con, *_call__bound__arguments.args, **_call__bound__arguments.kwargs)
+    assert result == 3
+    codeflash_con.close()
+"""
+
+EXPECTED_TORCH_GPU_PERFORMANCE = """import gc
+import os
+import time
+
+import torch
+from mymodule import my_function
+
+
+def codeflash_wrap(codeflash_wrapped, codeflash_test_module_name, codeflash_test_class_name, codeflash_test_name, codeflash_function_name, codeflash_line_id, codeflash_loop_index, *args, **kwargs):
+    test_id = f'{codeflash_test_module_name}:{codeflash_test_class_name}:{codeflash_test_name}:{codeflash_line_id}:{codeflash_loop_index}'
+    if not hasattr(codeflash_wrap, 'index'):
+        codeflash_wrap.index = {}
+    if test_id in codeflash_wrap.index:
+        codeflash_wrap.index[test_id] += 1
+    else:
+        codeflash_wrap.index[test_id] = 0
+    codeflash_test_index = codeflash_wrap.index[test_id]
+    invocation_id = f'{codeflash_line_id}_{codeflash_test_index}'
+    test_stdout_tag = f'{codeflash_test_module_name}:{(codeflash_test_class_name + '.' if codeflash_test_class_name else '')}{codeflash_test_name}:{codeflash_function_name}:{codeflash_loop_index}:{invocation_id}'
+    print(f'!$######{test_stdout_tag}######$!')
+    exception = None
+    _codeflash_use_gpu_timer = torch.cuda.is_available() and torch.cuda.is_initialized()
+    _codeflash_should_sync_cuda = torch.cuda.is_available() and torch.cuda.is_initialized()
+    _codeflash_should_sync_mps = not _codeflash_should_sync_cuda and hasattr(torch.backends, 'mps') and torch.backends.mps.is_available() and hasattr(torch.mps, 'synchronize')
+    gc.disable()
+    if _codeflash_use_gpu_timer:
+        try:
+            _codeflash_start_event = torch.cuda.Event(enable_timing=True)
+            _codeflash_end_event = torch.cuda.Event(enable_timing=True)
+            _codeflash_start_event.record()
+            return_value = codeflash_wrapped(*args, **kwargs)
+            _codeflash_end_event.record()
+            torch.cuda.synchronize()
+            codeflash_duration = int(_codeflash_start_event.elapsed_time(_codeflash_end_event) * 1000000)
+        except Exception as e:
+            torch.cuda.synchronize()
+            codeflash_duration = 0
+            exception = e
+    else:
+        try:
+            if _codeflash_should_sync_cuda:
+                torch.cuda.synchronize()
+            elif _codeflash_should_sync_mps:
+                torch.mps.synchronize()
+            counter = time.perf_counter_ns()
+            return_value = codeflash_wrapped(*args, **kwargs)
+            if _codeflash_should_sync_cuda:
+                torch.cuda.synchronize()
+            elif _codeflash_should_sync_mps:
+                torch.mps.synchronize()
+            codeflash_duration = time.perf_counter_ns() - counter
+        except Exception as e:
+            codeflash_duration = time.perf_counter_ns() - counter
+            exception = e
+    gc.enable()
+    print(f'!######{test_stdout_tag}:{codeflash_duration}######!')
+    if exception:
+        raise exception
+    return return_value
+
+def test_my_function():
+    codeflash_loop_index = int(os.environ['CODEFLASH_LOOP_INDEX'])
+    result = codeflash_wrap(my_function, 'test_example', None, 'test_my_function', 'my_function', '0', codeflash_loop_index, 1, 2)
+    assert result == 3
+"""
+
+EXPECTED_TORCH_ALIASED_GPU_BEHAVIOR = """import gc
+import inspect
+import os
+import sqlite3
+import time
+
+import dill as pickle
+import torch as th
+from mymodule import my_function
+
+
+def codeflash_wrap(codeflash_wrapped, codeflash_test_module_name, codeflash_test_class_name, codeflash_test_name, codeflash_function_name, codeflash_line_id, codeflash_loop_index, codeflash_cur, codeflash_con, *args, **kwargs):
+    test_id = f'{codeflash_test_module_name}:{codeflash_test_class_name}:{codeflash_test_name}:{codeflash_line_id}:{codeflash_loop_index}'
+    if not hasattr(codeflash_wrap, 'index'):
+        codeflash_wrap.index = {}
+    if test_id in codeflash_wrap.index:
+        codeflash_wrap.index[test_id] += 1
+    else:
+        codeflash_wrap.index[test_id] = 0
+    codeflash_test_index = codeflash_wrap.index[test_id]
+    invocation_id = f'{codeflash_line_id}_{codeflash_test_index}'
+    test_stdout_tag = f'{codeflash_test_module_name}:{(codeflash_test_class_name + '.' if codeflash_test_class_name else '')}{codeflash_test_name}:{codeflash_function_name}:{codeflash_loop_index}:{invocation_id}'
+    print(f'!$######{test_stdout_tag}######$!')
+    exception = None
+    _codeflash_use_gpu_timer = th.cuda.is_available() and th.cuda.is_initialized()
+    _codeflash_should_sync_cuda = th.cuda.is_available() and th.cuda.is_initialized()
+    _codeflash_should_sync_mps = not _codeflash_should_sync_cuda and hasattr(th.backends, 'mps') and th.backends.mps.is_available() and hasattr(th.mps, 'synchronize')
+    gc.disable()
+    if _codeflash_use_gpu_timer:
+        try:
+            _codeflash_start_event = th.cuda.Event(enable_timing=True)
+            _codeflash_end_event = th.cuda.Event(enable_timing=True)
+            _codeflash_start_event.record()
+            return_value = codeflash_wrapped(*args, **kwargs)
+            _codeflash_end_event.record()
+            th.cuda.synchronize()
+            codeflash_duration = int(_codeflash_start_event.elapsed_time(_codeflash_end_event) * 1000000)
+        except Exception as e:
+            th.cuda.synchronize()
+            codeflash_duration = 0
+            exception = e
+    else:
+        try:
+            if _codeflash_should_sync_cuda:
+                th.cuda.synchronize()
+            elif _codeflash_should_sync_mps:
+                th.mps.synchronize()
+            counter = time.perf_counter_ns()
+            return_value = codeflash_wrapped(*args, **kwargs)
+            if _codeflash_should_sync_cuda:
+                th.cuda.synchronize()
+            elif _codeflash_should_sync_mps:
+                th.mps.synchronize()
+            codeflash_duration = time.perf_counter_ns() - counter
+        except Exception as e:
+            codeflash_duration = time.perf_counter_ns() - counter
+            exception = e
+    gc.enable()
+    print(f'!######{test_stdout_tag}######!')
+    pickled_return_value = pickle.dumps(exception) if exception else pickle.dumps(return_value)
+    codeflash_cur.execute('INSERT INTO test_results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)', (codeflash_test_module_name, codeflash_test_class_name, codeflash_test_name, codeflash_function_name, codeflash_loop_index, invocation_id, codeflash_duration, pickled_return_value, 'function_call'))
+    codeflash_con.commit()
+    if exception:
+        raise exception
+    return return_value
+
+def test_my_function():
+    codeflash_loop_index = int(os.environ['CODEFLASH_LOOP_INDEX'])
+    codeflash_iteration = os.environ['CODEFLASH_TEST_ITERATION']
+    codeflash_con = sqlite3.connect(f'{CODEFLASH_DB_PATH}')
+    codeflash_cur = codeflash_con.cursor()
+    codeflash_cur.execute('CREATE TABLE IF NOT EXISTS test_results (test_module_path TEXT, test_class_name TEXT, test_function_name TEXT, function_getting_tested TEXT, loop_index INTEGER, iteration_id TEXT, runtime INTEGER, return_value BLOB, verification_type TEXT)')
+    _call__bound__arguments = inspect.signature(my_function).bind(1, 2)
+    _call__bound__arguments.apply_defaults()
+    result = codeflash_wrap(my_function, 'test_example', None, 'test_my_function', 'my_function', '0', codeflash_loop_index, codeflash_cur, codeflash_con, *_call__bound__arguments.args, **_call__bound__arguments.kwargs)
+    assert result == 3
+    codeflash_con.close()
+"""
+
+
+# ============================================================================
+# Tests for GPU timing mode
+# ============================================================================
+
+
+class TestInjectProfilingGpuTimingMode:
+    """Tests for inject_profiling_into_existing_test with gpu=True."""
+
+    def test_torch_gpu_behavior_mode(self, tmp_path: Path) -> None:
+        """Test instrumentation with PyTorch and gpu=True in BEHAVIOR mode."""
+        code = """import torch
+from mymodule import my_function
+
+def test_my_function():
+    result = my_function(1, 2)
+    assert result == 3
+"""
+        test_file = tmp_path / "test_example.py"
+        test_file.write_text(code)
+
+        func = FunctionToOptimize(function_name="my_function", parents=[], file_path=Path("mymodule.py"))
+
+        success, instrumented_code = inject_profiling_into_existing_test(
+            test_path=test_file,
+            call_positions=[CodePosition(5, 13)],
+            function_to_optimize=func,
+            tests_project_root=tmp_path,
+            mode=TestingMode.BEHAVIOR,
+            gpu=True,
+        )
+
+        result = normalize_instrumented_code(instrumented_code)
+        expected = EXPECTED_TORCH_GPU_BEHAVIOR
+        assert result == expected
+
+    def test_torch_gpu_performance_mode(self, tmp_path: Path) -> None:
+        """Test instrumentation with PyTorch and gpu=True in PERFORMANCE mode."""
+        code = """import torch
+from mymodule import my_function
+
+def test_my_function():
+    result = my_function(1, 2)
+    assert result == 3
+"""
+        test_file = tmp_path / "test_example.py"
+        test_file.write_text(code)
+
+        func = FunctionToOptimize(function_name="my_function", parents=[], file_path=Path("mymodule.py"))
+
+        success, instrumented_code = inject_profiling_into_existing_test(
+            test_path=test_file,
+            call_positions=[CodePosition(5, 13)],
+            function_to_optimize=func,
+            tests_project_root=tmp_path,
+            mode=TestingMode.PERFORMANCE,
+            gpu=True,
+        )
+
+        result = normalize_instrumented_code(instrumented_code)
+        expected = EXPECTED_TORCH_GPU_PERFORMANCE
+        assert result == expected
+
+    def test_torch_aliased_gpu_behavior_mode(self, tmp_path: Path) -> None:
+        """Test instrumentation with PyTorch alias and gpu=True in BEHAVIOR mode."""
+        code = """import torch as th
+from mymodule import my_function
+
+def test_my_function():
+    result = my_function(1, 2)
+    assert result == 3
+"""
+        test_file = tmp_path / "test_example.py"
+        test_file.write_text(code)
+
+        func = FunctionToOptimize(function_name="my_function", parents=[], file_path=Path("mymodule.py"))
+
+        success, instrumented_code = inject_profiling_into_existing_test(
+            test_path=test_file,
+            call_positions=[CodePosition(5, 13)],
+            function_to_optimize=func,
+            tests_project_root=tmp_path,
+            mode=TestingMode.BEHAVIOR,
+            gpu=True,
+        )
+
+        result = normalize_instrumented_code(instrumented_code)
+        expected = EXPECTED_TORCH_ALIASED_GPU_BEHAVIOR
+        assert result == expected
+
+    def test_no_torch_gpu_flag_uses_cpu_timing(self, tmp_path: Path) -> None:
+        """Test that gpu=True without torch uses standard CPU timing."""
+        code = """from mymodule import my_function
+
+def test_my_function():
+    result = my_function(1, 2)
+    assert result == 3
+"""
+        test_file = tmp_path / "test_example.py"
+        test_file.write_text(code)
+
+        func = FunctionToOptimize(function_name="my_function", parents=[], file_path=Path("mymodule.py"))
+
+        success, instrumented_code = inject_profiling_into_existing_test(
+            test_path=test_file,
+            call_positions=[CodePosition(4, 13)],
+            function_to_optimize=func,
+            tests_project_root=tmp_path,
+            mode=TestingMode.PERFORMANCE,
+            gpu=True,
+        )
+
+        result = normalize_instrumented_code(instrumented_code)
+        # gpu=True without torch should produce the same result as gpu=False
+        expected = EXPECTED_NO_FRAMEWORKS_PERFORMANCE
+        assert result == expected
+
+    def test_gpu_false_with_torch_uses_device_sync(self, tmp_path: Path) -> None:
+        """Test that gpu=False with torch uses device sync (existing behavior)."""
+        code = """import torch
+from mymodule import my_function
+
+def test_my_function():
+    result = my_function(1, 2)
+    assert result == 3
+"""
+        test_file = tmp_path / "test_example.py"
+        test_file.write_text(code)
+
+        func = FunctionToOptimize(function_name="my_function", parents=[], file_path=Path("mymodule.py"))
+
+        success, instrumented_code = inject_profiling_into_existing_test(
+            test_path=test_file,
+            call_positions=[CodePosition(5, 13)],
+            function_to_optimize=func,
+            tests_project_root=tmp_path,
+            mode=TestingMode.PERFORMANCE,
+            gpu=False,
+        )
+
+        result = normalize_instrumented_code(instrumented_code)
+        # gpu=False with torch should produce device sync code
+        expected = EXPECTED_TORCH_PERFORMANCE
+        assert result == expected
+
+    def test_torch_submodule_import_gpu_mode(self, tmp_path: Path) -> None:
+        """Test that gpu=True works with torch submodule imports like 'from torch import nn'."""
+        code = """from torch import nn
+from mymodule import my_function
+
+def test_my_function():
+    result = my_function(1, 2)
+    assert result == 3
+"""
+        test_file = tmp_path / "test_example.py"
+        test_file.write_text(code)
+
+        func = FunctionToOptimize(function_name="my_function", parents=[], file_path=Path("mymodule.py"))
+
+        success, instrumented_code = inject_profiling_into_existing_test(
+            test_path=test_file,
+            call_positions=[CodePosition(5, 13)],
+            function_to_optimize=func,
+            tests_project_root=tmp_path,
+            mode=TestingMode.PERFORMANCE,
+            gpu=True,
+        )
+
+        assert success
+        # Verify GPU timing code is present (torch detected from submodule import)
+        assert "_codeflash_use_gpu_timer = torch.cuda.is_available()" in instrumented_code
+        assert "torch.cuda.Event(enable_timing=True)" in instrumented_code
+        assert "elapsed_time" in instrumented_code
+
+    def test_torch_dotted_import_gpu_mode(self, tmp_path: Path) -> None:
+        """Test that gpu=True works with torch dotted imports like 'import torch.nn'."""
+        code = """import torch.nn
+from mymodule import my_function
+
+def test_my_function():
+    result = my_function(1, 2)
+    assert result == 3
+"""
+        test_file = tmp_path / "test_example.py"
+        test_file.write_text(code)
+
+        func = FunctionToOptimize(function_name="my_function", parents=[], file_path=Path("mymodule.py"))
+
+        success, instrumented_code = inject_profiling_into_existing_test(
+            test_path=test_file,
+            call_positions=[CodePosition(5, 13)],
+            function_to_optimize=func,
+            tests_project_root=tmp_path,
+            mode=TestingMode.PERFORMANCE,
+            gpu=True,
+        )
+
+        assert success
+        # Verify GPU timing code is present (torch detected from dotted import)
+        assert "_codeflash_use_gpu_timer = torch.cuda.is_available()" in instrumented_code
+        assert "torch.cuda.Event(enable_timing=True)" in instrumented_code
+        assert "elapsed_time" in instrumented_code


### PR DESCRIPTION
## Summary
- Add a `gpu` parameter to `inject_profiling_into_existing_test()` and `create_wrapper_function()` for CUDA event-based timing
- When `gpu=True` and torch is detected, uses `torch.cuda.Event` timing instead of `time.perf_counter_ns()` for measuring GPU kernel execution time exclusively
- Falls back to CPU timing with device sync when CUDA is not available/initialized at runtime

## Changes
- Updated function signatures with `gpu: bool = False` parameter
- Added `_create_gpu_event_timing_precompute_statements()` for runtime CUDA availability check
- Added `_create_gpu_timing_try_body()` and `_create_gpu_timing_except_body()` for GPU event timing code generation
- Refactored CPU timing into `_create_cpu_timing_try_body()` and `_create_cpu_timing_except_body()`
- Added `_create_timing_try_block()` to orchestrate GPU vs CPU timing paths

## Generated Code Structure (when gpu=True with torch)
```python
_codeflash_use_gpu_timer = torch.cuda.is_available() and torch.cuda.is_initialized()
gc.disable()
if _codeflash_use_gpu_timer:
    try:
        _codeflash_start_event = torch.cuda.Event(enable_timing=True)
        _codeflash_end_event = torch.cuda.Event(enable_timing=True)
        _codeflash_start_event.record()
        return_value = codeflash_wrapped(*args, **kwargs)
        _codeflash_end_event.record()
        torch.cuda.synchronize()
        codeflash_duration = int(_codeflash_start_event.elapsed_time(_codeflash_end_event) * 1000000)
    except Exception as e:
        torch.cuda.synchronize()
        codeflash_duration = 0
        exception = e
else:
    # CPU timing fallback with device sync
```

## Test plan
- [x] All existing 29 framework tests pass (no regressions)
- [x] Added 5 new tests for GPU timing mode:
  - `test_torch_gpu_behavior_mode` - GPU timing with torch in BEHAVIOR mode
  - `test_torch_gpu_performance_mode` - GPU timing with torch in PERFORMANCE mode
  - `test_torch_aliased_gpu_behavior_mode` - GPU timing with torch alias
  - `test_no_torch_gpu_flag_uses_cpu_timing` - gpu=True without torch uses CPU timing
  - `test_gpu_false_with_torch_uses_device_sync` - gpu=False with torch uses device sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)