### PR TITLE
fix: correct Java test file path generation for Maven structure

### DIFF
--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -758,6 +758,17 @@ class FunctionOptimizer:
         tests_root = self.test_cfg.tests_root
         parts = tests_root.parts
 
+        # Check if tests_root already ends with src/test/java (Maven-standard)
+        if len(parts) >= 3 and parts[-3:] == ("src", "test", "java"):
+            logger.debug(f"[JAVA] tests_root already is Maven-standard test directory: {tests_root}")
+            return tests_root
+
+        # Check for Maven-standard src/test/java structure as subdirectory
+        maven_test_dir = tests_root / "src" / "test" / "java"
+        if maven_test_dir.exists() and maven_test_dir.is_dir():
+            logger.debug(f"[JAVA] Found Maven-standard test directory as subdirectory: {maven_test_dir}")
+            return maven_test_dir
+
         # Look for standard Java package prefixes that indicate the start of package structure
         standard_package_prefixes = ("com", "org", "net", "io", "edu", "gov")
 


### PR DESCRIPTION
## Summary

This PR fixes a critical path generation bug that was preventing Java test files from being written to Maven's standard `src/test/java/` directory structure.

## Problem Fixed

Generated Java test files were written to incorrect paths outside Maven's standard directory structure, causing compilation to fail:

**Before:**
- Test file 0 & 1: `/project/com/example/Test.java` ❌ (outside src/)  
- Test file 2: `/project/src/test/java/com/example/Test.java` ✅

**After:**
- All test files: `/project/src/test/java/com/example/Test.java` ✅

## Root Cause

The `_get_java_sources_root()` function in `function_optimizer.py` didn't handle two common scenarios:

1. When `tests_root` is the project root - it would find "java" in path components and return wrong directory
2. When `tests_root` is already `src/test/java` - it would try to append `src/test/java` again, creating duplicate path

## Solution

Added two checks at the beginning of `_get_java_sources_root()`:

```python
# Check if tests_root already ends with src/test/java (Maven-standard)
if len(parts) >= 3 and parts[-3:] == ("src", "test", "java"):
    logger.debug(f"[JAVA] tests_root already is Maven-standard test directory: {tests_root}")
    return tests_root

# Check for Maven-standard src/test/java structure as subdirectory  
maven_test_dir = tests_root / "src" / "test" / "java"
if maven_test_dir.exists() and maven_test_dir.is_dir():
    logger.debug(f"[JAVA] Found Maven-standard test directory as subdirectory: {maven_test_dir}")
    return maven_test_dir
```

## Code Changes

**File:** `codeflash/optimization/function_optimizer.py`  
**Function:** `_get_java_sources_root()` (lines 758-779)  
**Changes:** +11 lines (2 checks with logging)

## Testing

1. **E2E Test:** Ran full Java optimization with local backend
2. **Path Verification:** Confirmed all test files created in `src/test/java/com/example/`
3. **Maven Integration:** Verified Maven can now find test files for compilation

**Test Output:**
```
DEBUG [JAVA] tests_root already is Maven-standard test directory: .../src/test/java
DEBUG [PIPELINE] Test file 0: .../src/test/java/com/example/Test__perfinstrumented.java ✅
DEBUG [PIPELINE] Test file 1: .../src/test/java/com/example/Test__perfinstrumented_2.java ✅
DEBUG [PIPELINE] Test file 2: .../src/test/java/com/example/Test__perfinstrumented.java ✅
```

## Impact

**Before Fix:**
- ❌ Maven couldn't find test files
- ❌ Compilation failed immediately  
- ❌ Blocked entire Java E2E optimization pipeline
- ❌ No baseline establishment or verification possible

**After Fix:**
- ✅ All test files in Maven-standard location
- ✅ Maven can find and compile test files
- ✅ Path bug completely resolved
- ✅ E2E pipeline can proceed

## Notes

- **Clean, focused fix:** Only touches path generation logic
- **No breaking changes:** Preserves existing behavior for edge cases
- **Well-tested:** Verified with real E2E Java optimization flow
- **Backwards compatible:** Falls back to existing logic when needed

## Related

This fix resolves the path generation bug discovered during Java E2E testing. A separate instrumentation bug (invalid exception handling syntax) was also discovered but is unrelated to this fix and will be addressed separately.