### PR TITLE
docs: add Java runtime README with Maven cache troubleshooting

### DIFF
--- a/codeflash-java-runtime/README.md
+++ b/codeflash-java-runtime/README.md
@@ -1,0 +1,75 @@
+# Codeflash Java Runtime
+
+This module provides the runtime library required for Java code optimization with Codeflash.
+
+## Components
+
+- **Serializer**: Handles serialization of test results for behavioral verification
+- **Helper utilities**: Supporting classes for instrumented test execution
+
+## Building
+
+```bash
+mvn clean package -DskipTests
+```
+
+This generates `target/codeflash-runtime-1.0.0.jar`.
+
+## Installation
+
+After making changes to the runtime, you must install it to your local Maven repository for projects to pick up the updates:
+
+```bash
+mvn clean install -DskipTests
+```
+
+This installs the JAR to `~/.m2/repository/com/codeflash/codeflash-runtime/1.0.0/`.
+
+## Troubleshooting
+
+### Maven Compilation Errors After Runtime Updates
+
+**Symptom:** After updating the runtime code, Maven compilation fails with method signature mismatches like:
+
+```
+method serialize in class com.codeflash.Serializer cannot be applied to given types;
+  required: [old signature]
+  found: [new signature]
+```
+
+**Cause:** Maven is using a cached version of the runtime JAR from `~/.m2/repository/` that doesn't match the updated source code.
+
+**Solution:** Reinstall the runtime JAR to your local Maven repository:
+
+```bash
+cd codeflash-java-runtime
+mvn clean install -DskipTests
+```
+
+### Verifying Installation
+
+Check that the JAR timestamp matches your recent build:
+
+```bash
+ls -lh ~/.m2/repository/com/codeflash/codeflash-runtime/1.0.0/codeflash-runtime-1.0.0.jar
+```
+
+## Usage in Projects
+
+Projects using the Codeflash runtime should have this dependency in their `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>com.codeflash</groupId>
+    <artifactId>codeflash-runtime</artifactId>
+    <version>1.0.0</version>
+    <scope>system</scope>
+    <systemPath>${project.basedir}/codeflash-runtime-1.0.0.jar</systemPath>
+</dependency>
+```
+
+**Important:** After updating the runtime, copy the new JAR to your project directory:
+
+```bash
+cp codeflash-java-runtime/target/codeflash-runtime-1.0.0.jar your-project/
+```


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the `codeflash-java-runtime` module to help developers troubleshoot common Maven cache issues.

## Problems Fixed

### Issue: Maven Compilation Failures After Runtime Updates

When the Java runtime source code is updated but Maven's local repository cache isn't refreshed, projects fail to compile with errors like:

```
method serialize in class com.codeflash.Serializer cannot be applied to given types;
  required: Object, IdentityHashMap<Object,Boolean>, int
  found: Object
```

### Root Cause

Maven caches JARs in `~/.m2/repository/com/codeflash/codeflash-runtime/1.0.0/`. When the runtime source is updated but the cache isn't refreshed, Maven uses the stale cached JAR instead of the newly built one, causing method signature mismatches.

## Solutions Implemented

### 1. README.md Documentation

Added comprehensive README with:
- **Build instructions:** How to package the runtime JAR
- **Installation instructions:** How to install to local Maven repository
- **Troubleshooting section:** Common Maven cache errors and solutions
- **Verification steps:** How to check JAR timestamps
- **Project usage:** How to properly configure the runtime dependency

### 2. Clear Resolution Steps

```bash
cd codeflash-java-runtime
mvn clean install -DskipTests
```

This command:
1. Cleans any previous builds
2. Rebuilds the runtime JAR
3. Installs it to `~/.m2/repository/` (Maven local cache)
4. Makes updated runtime available to all projects

## Code Changes

- **New file:** `codeflash-java-runtime/README.md`
- **Type:** Documentation only
- **Impact:** Helps developers resolve compilation issues faster

## Testing

Verified the fix resolves the compilation issue:
1. Before: Maven compilation failed with method signature mismatch
2. After `mvn clean install`: Maven compilation succeeded ✅
3. Test execution: Maven tests passed with return code 0 ✅

## Impact

- **Developers:** Clear documentation for troubleshooting
- **CI/CD:** Guidelines for keeping runtime JARs up to date
- **Onboarding:** New contributors can resolve cache issues independently

🤖 Generated with Claude Code