### PR TITLE
Fix CrossHair subprocess missing PYTHONPATH

### DIFF
--- a/codeflash/verification/concolic_testing.py
+++ b/codeflash/verification/concolic_testing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import os
 import subprocess
 import tempfile
 import time
@@ -63,6 +64,13 @@ def generate_concolic_tests(
         logger.info("Generating concolic opcode coverage tests for the original code…")
         console.rule()
         try:
+            env = os.environ.copy()
+            pythonpath = env.get("PYTHONPATH", "")
+            project_root_str = str(args.project_root)
+            if pythonpath:
+                env["PYTHONPATH"] = f"{project_root_str}{os.pathsep}{pythonpath}"
+            else:
+                env["PYTHONPATH"] = project_root_str
             cover_result = subprocess.run(
                 [
                     SAFE_SYS_EXECUTABLE,
@@ -86,6 +94,7 @@ def generate_concolic_tests(
                 cwd=args.project_root,
                 check=False,
                 timeout=600,
+                env=env,
             )
         except subprocess.TimeoutExpired:
             logger.debug("CrossHair Cover test generation timed out")


### PR DESCRIPTION
## Summary
- Prepend `project_root` to `PYTHONPATH` before spawning the CrossHair subprocess in `concolic_testing.py`, matching the pattern used by every other subprocess (tracer, test runner, benchmarks).
- Fixes `ModuleNotFoundError` for project-relative imports (e.g. Django projects) during concolic test generation.

## Test plan
- [x] Existing concolic tests pass (88/88)
- [ ] Verify CrossHair resolves project-relative imports in a Django-style project