### PR TITLE
[FIX] path mismatch for behavior_file_path for original baseline, resulting into empty validated test source

### DIFF
--- a/codeflash/optimization/function_optimizer.py
+++ b/codeflash/optimization/function_optimizer.py
@@ -2077,7 +2077,10 @@ class FunctionOptimizer:
         generated_tests_str = ""
         code_lang = self.function_to_optimize.language
         for test in generated_tests.generated_tests:
-            if map_gen_test_file_to_no_of_tests[test.behavior_file_path] > 0:
+            if any(
+                test_file.name == test.behavior_file_path.name and count > 0
+                for test_file, count in map_gen_test_file_to_no_of_tests.items()
+            ):
                 formatted_generated_test = format_generated_code(
                     test.generated_original_test_source, self.args.formatter_cmds
                 )


### PR DESCRIPTION
this is a temporary fix until I find a fix for the incorrect path

```bash
[WARNING] No tests found for /home/mohammed/Work/novu/tests/test_build__unit_test_0.test.ts. existing tests: Counter({PosixPath('/home/mohammed/Work/novu/tests/../../tests/test_build__unit_test_1.test.ts'): 9, PosixPath('/home/mohammed/Work/novu/tests/../../tests/test_build__unit_test_0.test.ts'): 9})
[WARNING] No tests found for /home/mohammed/Work/novu/tests/test_build__unit_test_1.test.ts. existing tests: Counter({PosixPath('/home/mohammed/Work/novu/tests/../../tests/test_build__unit_test_1.test.ts'): 9, PosixPath('/home/mohammed/Work/novu/tests/../../tests/test_build__unit_test_0.test.ts'): 9})

```

the issue:
https://github.com/mohammedahmed18/novu/pull/63
the fix:
https://github.com/mohammedahmed18/novu/pull/69