### PR TITLE
chore: release v0.20.1

### DIFF
--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,2 +1,2 @@
 # These version placeholders will be replaced by uv-dynamic-versioning during build.
-__version__ = "0.20.0"
+__version__ = "0.20.1"


### PR DESCRIPTION
Bump version to 0.20.1 to trigger a PyPI release.