### PR TITLE
fix: handle itertools types in comparator with Python 3.9-3.14 support

### DIFF
--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -690,11 +690,17 @@ def test_itertools_groupby() -> None:
     )
 
 
-def test_itertools_pairwise_batched() -> None:
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="itertools.pairwise requires Python 3.10+")
+def test_itertools_pairwise() -> None:
     import itertools
 
     assert comparator(itertools.pairwise([1, 2, 3, 4]), itertools.pairwise([1, 2, 3, 4]))
     assert not comparator(itertools.pairwise([1, 2, 3, 4]), itertools.pairwise([1, 2, 3, 5]))
+
+
+@pytest.mark.skipif(sys.version_info < (3, 12), reason="itertools.batched requires Python 3.12+")
+def test_itertools_batched() -> None:
+    import itertools
 
     assert comparator(itertools.batched("ABCDEFG", 3), itertools.batched("ABCDEFG", 3))
     assert not comparator(itertools.batched("ABCDEFG", 3), itertools.batched("ABCDEFG", 2))


### PR DESCRIPTION
## Summary
- Added comparator handlers for all `itertools` types: `count`, `repeat`, `cycle`, `chain`, `islice`, `product`, `permutations`, `combinations`, `accumulate`, `groupby`, `starmap`, `compress`, `dropwhile`, `takewhile`, `filterfalse`, `zip_longest`, `pairwise`, `batched`, and more
- `count` and `repeat` use `repr()` comparison; `cycle` uses `__reduce__` with a fallback for Python 3.14+ (where `__reduce__` was removed) that samples elements; `groupby` materializes groups; all others materialize to lists
- Added version guards for `pairwise` (3.10+) and `batched` (3.12+) tests
- Comprehensive test coverage across Python 3.10–3.14

## Test plan
- [x] All comparator tests pass on Python 3.10 (157 passed, 46 skipped)
- [x] All comparator tests pass on Python 3.11 (159 passed, 44 skipped)
- [x] All comparator tests pass on Python 3.12 (160 passed, 43 skipped)
- [x] All comparator tests pass on Python 3.13 (160 passed, 43 skipped)
- [x] All comparator tests pass on Python 3.14 (160 passed, 43 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)