### PR TITLE
feat(java): skip inner-class methods in discovery; revert replacement-level workarounds

### DIFF
--- a/codeflash/languages/java/discovery.py
+++ b/codeflash/languages/java/discovery.py
@@ -129,6 +129,11 @@ def _should_include_method(
         True if the method should be included.
 
     """
+    # Skip methods that belong to an inner/nested class — they cannot be reliably
+    # instrumented or tested in isolation (see discussion in discovery module).
+    if method.is_class_nested:
+        return False
+
     # Skip abstract methods (no implementation to optimize)
     if method.is_abstract:
         return False

--- a/codeflash/languages/java/parser.py
+++ b/codeflash/languages/java/parser.py
@@ -53,6 +53,7 @@ class JavaMethodNode:
     source_text: str
     javadoc_start_line: int | None = None  # Line where Javadoc comment starts
     formal_parameters_text: str | None = None  # Raw formal parameters "(Type name, ...)" for matching
+    is_class_nested: bool = False  # True when the enclosing class is itself nested inside another class
 
 
 @dataclass
@@ -289,6 +290,7 @@ class JavaAnalyzer:
         include_private: bool,
         include_static: bool,
         current_class: str | None,
+        class_depth: int = 0,
     ) -> None:
         """Recursively walk the tree to find method definitions."""
         new_class = current_class
@@ -304,6 +306,10 @@ class JavaAnalyzer:
             method_info = self._extract_method_info(node, source_bytes, current_class)
 
             if method_info:
+                # A method is nested when its enclosing class is itself inside another
+                # class (class_depth >= 2: depth 1 = outermost class, depth 2+ = nested).
+                method_info.is_class_nested = class_depth >= 2
+
                 # Apply filters
                 should_include = True
 
@@ -316,7 +322,7 @@ class JavaAnalyzer:
                 if should_include:
                     methods.append(method_info)
 
-        # Recurse into children
+        # Recurse into children, incrementing depth when entering a type declaration
         for child in node.children:
             self._walk_tree_for_methods(
                 child,
@@ -325,6 +331,7 @@ class JavaAnalyzer:
                 include_private=include_private,
                 include_static=include_static,
                 current_class=new_class if node.type in type_declarations else current_class,
+                class_depth=class_depth + 1 if node.type in type_declarations else class_depth,
             )
 
     def _extract_method_info(self, node: Node, source_bytes: bytes, current_class: str | None) -> JavaMethodNode | None:

--- a/codeflash/languages/java/replacement.py
+++ b/codeflash/languages/java/replacement.py
@@ -42,7 +42,6 @@ def _parse_optimization_source(
     new_source: str,
     target_method_name: str,
     analyzer: JavaAnalyzer,
-    target_class_name: str | None = None,
 ) -> ParsedOptimization:
     """Parse optimization source to extract method and additional class members.
 
@@ -54,11 +53,6 @@ def _parse_optimization_source(
         new_source: The optimization source code.
         target_method_name: Name of the method being optimized.
         analyzer: JavaAnalyzer instance.
-        target_class_name: Optional name of the class that owns the target method.
-            When provided and the generated code contains multiple methods with the
-            same name (e.g. an abstract method in an outer class AND the concrete
-            override in an inner class), the method whose ``class_name`` matches
-            this value is preferred as the actual replacement target.
 
     Returns:
         ParsedOptimization with the method and any additional members.
@@ -86,17 +80,9 @@ def _parse_optimization_source(
         target_method_index: int | None = None
         for i, method in enumerate(methods):
             if method.name == target_method_name:
-                # When a target_class_name is known, prefer the method in that class
-                # (e.g. ObjectUnpacker.getString over the abstract outer getString).
-                # Still accept any match as fallback if no class-specific one is found.
-                if target_class_name is None or method.class_name == target_class_name:
-                    target_method = method
-                    target_method_index = i
-                    break
-                elif target_method is None:
-                    # Keep as tentative fallback (class didn't match yet)
-                    target_method = method
-                    target_method_index = i
+                target_method = method
+                target_method_index = i
+                break
 
         if target_method:
             # Extract target method source (including Javadoc if present)
@@ -116,11 +102,6 @@ def _parse_optimization_source(
         # Skip methods whose line range falls entirely inside the target method's
         # range, as these belong to anonymous/inner classes inside the target body
         # and must not be hoisted out as top-level class members.
-        # Also skip methods that belong to a different class than the target — this
-        # handles the case where the target is in an inner class and the generated
-        # code also contains outer-class methods that must not be injected into the
-        # inner class (outer-class methods would reference type parameters or instance
-        # variables that are not in scope inside a static inner class).
         lines = new_source.splitlines(keepends=True)
         for i, method in enumerate(methods):
             if method.name != target_method_name:
@@ -128,9 +109,6 @@ def _parse_optimization_source(
                 if target_method and (
                     method.start_line >= target_method.start_line and method.end_line <= target_method.end_line
                 ):
-                    continue
-                # Skip methods from a different class than the target method
-                if target_method and method.class_name != target_method.class_name:
                     continue
                 start = (method.javadoc_start_line or method.start_line) - 1
                 end = method.end_line
@@ -434,10 +412,7 @@ def replace_function(
     func_end_line = function.ending_line
 
     # Parse the optimization to extract components.
-    # Pass the class name so that when the generated code contains multiple
-    # methods with the same name (outer abstract + inner concrete), the correct
-    # one is selected as the replacement target.
-    parsed = _parse_optimization_source(new_source, func_name, analyzer, target_class_name=function.class_name)
+    parsed = _parse_optimization_source(new_source, func_name, analyzer)
 
     # If the parsed optimization has no valid target source (e.g., the LLM generated
     # a method with a different name), skip this candidate entirely.

--- a/tests/test_languages/test_java/test_context.py
+++ b/tests/test_languages/test_java/test_context.py
@@ -1486,7 +1486,11 @@ class TestExtractCodeContextWithInnerClasses:
     """Tests for extract_code_context with inner/nested classes."""
 
     def test_static_nested_class_method(self, tmp_path: Path):
-        """Test context extraction for static nested class method."""
+        """Inner class methods are excluded from discovery and cannot be context-extracted.
+
+        Methods of static nested classes are skipped in discovery because they
+        cannot be reliably instrumented or tested in isolation.
+        """
         java_file = tmp_path / "Container.java"
         java_file.write_text("""public class Container {
     public static class Nested {
@@ -1498,26 +1502,15 @@ class TestExtractCodeContextWithInnerClasses:
 """)
         functions = discover_functions_from_source(java_file.read_text(), file_path=java_file)
         compute_func = next((f for f in functions if f.function_name == "compute"), None)
-        assert compute_func is not None
-
-        context = extract_code_context(compute_func, tmp_path)
-
-        # Inner class wrapped in outer class skeleton
-        assert (
-            context.target_code
-            == """public class Container {
-    public static class Nested {
-        public int compute(int x) {
-            return x * 2;
-        }
-    }
-}
-"""
-        )
-        assert context.read_only_context == ""
+        # Inner class method must NOT be discovered
+        assert compute_func is None
 
     def test_inner_class_method(self, tmp_path: Path):
-        """Test context extraction for inner class method."""
+        """Inner class methods are excluded from discovery and cannot be context-extracted.
+
+        Methods of non-static inner classes are skipped in discovery because they
+        require an outer instance and cannot be instrumented independently.
+        """
         java_file = tmp_path / "Outer.java"
         java_file.write_text("""public class Outer {
     private int value = 10;
@@ -1531,23 +1524,8 @@ class TestExtractCodeContextWithInnerClasses:
 """)
         functions = discover_functions_from_source(java_file.read_text(), file_path=java_file)
         get_func = next((f for f in functions if f.function_name == "getValue"), None)
-        assert get_func is not None
-
-        context = extract_code_context(get_func, tmp_path)
-
-        # Inner class wrapped in outer class skeleton
-        assert (
-            context.target_code
-            == """public class Outer {
-    public class Inner {
-        public int getValue() {
-            return value;
-        }
-    }
-}
-"""
-        )
-        assert context.read_only_context == ""
+        # Inner class method must NOT be discovered
+        assert get_func is None
 
 
 class TestExtractCodeContextWithEnumAndInterface:

--- a/tests/test_languages/test_java/test_discovery.py
+++ b/tests/test_languages/test_java/test_discovery.py
@@ -333,3 +333,122 @@ class TestFileBasedDiscovery:
 
         tests = discover_test_methods(test_file)
         assert len(tests) > 0
+
+
+class TestInnerClassMethodFilter:
+    """Tests that methods of nested/inner classes are excluded from discovery.
+
+    Inner class methods cannot be reliably instrumented or tested in isolation:
+    - Non-static inner classes require an outer instance
+    - Protected methods are inaccessible from external test code
+    - The instrumentation layer is not class-aware (wraps by method name only)
+
+    Discovery must skip all methods whose enclosing class is itself nested inside
+    another class.
+    """
+
+    def test_static_inner_class_methods_are_excluded(self):
+        """Methods in a static nested class must not be discovered."""
+        source = """\
+public abstract class Unpacker<T> {
+    protected abstract T getString(String value);
+
+    public T unpackString() {
+        return getString(null);
+    }
+
+    public static final class ObjectUnpacker extends Unpacker<Object> {
+        public ObjectUnpacker() {}
+
+        @Override
+        protected Object getString(String value) {
+            return value;
+        }
+
+        public Object helper() {
+            return null;
+        }
+    }
+}
+"""
+        functions = discover_functions_from_source(source)
+        # Only the outer class method unpackString() should be discovered.
+        # ObjectUnpacker.getString and ObjectUnpacker.helper are inner-class methods
+        # and must be excluded.
+        function_names = {f.function_name for f in functions}
+        assert "unpackString" in function_names
+        assert "getString" not in function_names
+        assert "helper" not in function_names
+
+    def test_non_static_inner_class_methods_are_excluded(self):
+        """Methods in a non-static inner class must not be discovered."""
+        source = """\
+public class Outer {
+    private int value;
+
+    public int getValue() {
+        return value;
+    }
+
+    public class Inner {
+        public int doubleValue() {
+            return value * 2;
+        }
+    }
+}
+"""
+        functions = discover_functions_from_source(source)
+        function_names = {f.function_name for f in functions}
+        assert "getValue" in function_names
+        assert "doubleValue" not in function_names
+
+    def test_outer_class_methods_are_still_discovered(self):
+        """Outer-class methods must be discovered normally even when inner classes exist."""
+        source = """\
+public class Container {
+    public int size() {
+        return 0;
+    }
+
+    public boolean isEmpty() {
+        return true;
+    }
+
+    private static class InnerHelper {
+        public void doWork() {}
+    }
+}
+"""
+        functions = discover_functions_from_source(source)
+        function_names = {f.function_name for f in functions}
+        assert "size" in function_names
+        assert "isEmpty" in function_names
+        # Inner class method must be excluded
+        assert "doWork" not in function_names
+
+    def test_deeply_nested_class_methods_are_excluded(self):
+        """Methods in classes nested more than two levels deep must also be excluded."""
+        source = """\
+public class Level1 {
+    public int method1() {
+        return 1;
+    }
+
+    public static class Level2 {
+        public int method2() {
+            return 2;
+        }
+
+        public static class Level3 {
+            public int method3() {
+                return 3;
+            }
+        }
+    }
+}
+"""
+        functions = discover_functions_from_source(source)
+        function_names = {f.function_name for f in functions}
+        assert "method1" in function_names
+        assert "method2" not in function_names
+        assert "method3" not in function_names

--- a/tests/test_languages/test_java/test_replacement.py
+++ b/tests/test_languages/test_java/test_replacement.py
@@ -832,8 +832,12 @@ public class MathOps {{
 class TestNestedClasses:
     """Tests for nested class scenarios."""
 
-    def test_replace_method_in_nested_class(self, tmp_path: Path):
-        """Test replacing a method in a nested class."""
+    def test_inner_class_method_is_not_replaced(self, tmp_path: Path):
+        """Inner-class methods are not supported for optimization and must be skipped.
+
+        Methods of static nested or non-static inner classes are excluded from
+        discovery and therefore cannot be replaced via the high-level API.
+        """
         java_file = tmp_path / "Outer.java"
         original_code = """public class Outer {
     public int outerMethod() {
@@ -865,6 +869,8 @@ public class Outer {{
 
         optimized_code = CodeStringsMarkdown.parse_markdown_code(optimized_markdown, expected_language="java")
 
+        # Inner class methods are excluded from discovery, so the replacement
+        # is a no-op and the original file must remain unchanged.
         result = replace_function_definitions_for_language(
             function_names=["innerMethod"],
             optimized_code=optimized_code,
@@ -872,21 +878,9 @@ public class Outer {{
             project_root_path=tmp_path,
         )
 
-        assert result is True
-        new_code = java_file.read_text(encoding="utf-8")
-        expected = """public class Outer {
-    public int outerMethod() {
-        return 1;
-    }
-
-    public static class Inner {
-        public int innerMethod() {
-            return 2 + 0;
-        }
-    }
-}
-"""
-        assert new_code == expected
+        assert result is False
+        # File must be unchanged
+        assert java_file.read_text(encoding="utf-8") == original_code
 
 
 class TestPreservesStructure:
@@ -1923,141 +1917,6 @@ public final class LuaMap {
 
     public int size() {
         return map.size();
-    }
-}
-"""
-        assert new_code == expected_code
-
-
-class TestInnerClassHelperFilter:
-    """Tests that outer-class methods are not injected into a static inner class.
-
-    When the target method lives in a *static* inner class (e.g. ObjectUnpacker),
-    the generated optimisation class typically wraps the inner class inside the
-    outer class.  Methods that belong to the outer class must NOT be extracted as
-    helpers and inserted into the inner class — they would reference outer-class
-    type parameters or instance variables that are unavailable in a static context.
-    """
-
-    def test_outer_class_methods_not_injected_into_static_inner_class(self, tmp_path):
-        """Reproduces the Unpacker.ObjectUnpacker.getString bug.
-
-        The outer class ``Unpacker<T>`` has a method ``getString(String)``.
-        When the LLM generates an optimisation for ``ObjectUnpacker.getString``,
-        the generated file still contains the outer ``Unpacker<T>`` skeleton.
-        Codeflash must NOT inject the outer ``getString`` helper into the
-        ``ObjectUnpacker`` inner class.
-        """
-        from codeflash.discovery.functions_to_optimize import FunctionToOptimize, FunctionParent
-        from codeflash.languages.java.replacement import replace_function
-
-        original_code = """\
-public abstract class Unpacker<T> {
-    protected byte[] buffer;
-    protected int offset;
-    protected int length;
-
-    public Unpacker(byte[] buffer, int offset, int length) {
-        this.buffer = buffer;
-        this.offset = offset;
-        this.length = length;
-    }
-
-    protected abstract T getString(String value);
-
-    public T unpackString() {
-        return getString(new String(buffer, offset, length));
-    }
-
-    public static final class ObjectUnpacker extends Unpacker<Object> {
-        public ObjectUnpacker(byte[] buffer, int offset, int length) {
-            super(buffer, offset, length);
-        }
-
-        @Override
-        protected Object getString(String value) {
-            return value;
-        }
-    }
-}
-"""
-        java_file = tmp_path / "Unpacker.java"
-        java_file.write_text(original_code, encoding="utf-8")
-
-        # LLM-generated optimisation: the outer class is present in the generated
-        # code, but only ObjectUnpacker.getString is the actual optimisation target.
-        optimized_source = """\
-public abstract class Unpacker<T> {
-    protected byte[] buffer;
-    protected int offset;
-    protected int length;
-
-    public Unpacker(byte[] buffer, int offset, int length) {
-        this.buffer = buffer;
-        this.offset = offset;
-        this.length = length;
-    }
-
-    protected abstract T getString(String value);
-
-    public T unpackString() {
-        return getString(new String(buffer, offset, length));
-    }
-
-    public static final class ObjectUnpacker extends Unpacker<Object> {
-        public ObjectUnpacker(byte[] buffer, int offset, int length) {
-            super(buffer, offset, length);
-        }
-
-        @Override
-        protected Object getString(String value) {
-            return value.intern();
-        }
-    }
-}
-"""
-
-        func = FunctionToOptimize(
-            function_name="getString",
-            file_path=java_file,
-            starting_line=21,
-            ending_line=23,
-            parents=[FunctionParent(name="ObjectUnpacker", type="ClassDef")],
-            is_method=True,
-            language="java",
-        )
-
-        new_code = replace_function(original_code, func, optimized_source)
-
-        # The outer-class unpackString() method must NOT be inserted into ObjectUnpacker.
-        # The result should only differ from the original in the ObjectUnpacker.getString body.
-        expected_code = """\
-public abstract class Unpacker<T> {
-    protected byte[] buffer;
-    protected int offset;
-    protected int length;
-
-    public Unpacker(byte[] buffer, int offset, int length) {
-        this.buffer = buffer;
-        this.offset = offset;
-        this.length = length;
-    }
-
-    protected abstract T getString(String value);
-
-    public T unpackString() {
-        return getString(new String(buffer, offset, length));
-    }
-
-    public static final class ObjectUnpacker extends Unpacker<Object> {
-        public ObjectUnpacker(byte[] buffer, int offset, int length) {
-            super(buffer, offset, length);
-        }
-
-        @Override
-        protected Object getString(String value) {
-            return value.intern();
-        }
     }
 }
 """


### PR DESCRIPTION
## Summary

- **parser.py**: Add `is_class_nested` flag to `JavaMethodNode`; track `class_depth` in `_walk_tree_for_methods` (incremented on each type declaration entry). Methods at depth ≥ 2 have `is_class_nested = True`.
- **discovery.py**: Skip methods with `is_class_nested = True` in `_should_include_method`. Inner-class methods cannot be reliably instrumented (instrumentation is name-only, not class-aware), and non-static inner classes require an outer instance unavailable in tests.
- **replacement.py**: Revert the replacement-level Bug-4 workarounds that are now obsolete — removing `target_class_name` parameter, restoring simple first-match selection, and removing the class-name filter for helpers.
- **tests**: Update existing inner-class tests to reflect the new contract; add `TestInnerClassMethodFilter` in `test_discovery.py` with four scenarios (static nested, non-static inner, outer-only, deeply nested).

## Test plan

- [ ] `uv run python -m pytest tests/test_languages/test_java/test_discovery.py` — new `TestInnerClassMethodFilter` class passes
- [ ] `uv run python -m pytest tests/test_languages/test_java/test_replacement.py` — all pass (removed obsolete `TestInnerClassHelperFilter`)
- [ ] `uv run python -m pytest tests/test_languages/test_java/test_context.py` — updated inner-class context tests pass
- [ ] Full Java suite: 639 passed, 0 new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)