### PR TITLE
chore: limit claude workflow triggers to reduce spam

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,6 +4,17 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    paths-ignore:
+      - '.github/workflows/**'
+      - '*.md'
+      - 'docs/**'
+      - 'demos/**'
+      - 'experiments/**'
+      - 'LICENSE'
+      - '.tessl/**'
+      - 'code_to_optimize/**'
+      - 'codeflash.code-workspace'
+      - 'uv.lock'
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -23,7 +34,7 @@ jobs:
     if: |
       (
         github.event_name == 'pull_request' &&
-        github.actor != 'claude[bot]' &&
+        github.event.sender.login != 'claude[bot]' &&
         github.event.pull_request.head.repo.full_name == github.repository
       ) ||
       github.event_name == 'workflow_dispatch'
@@ -76,6 +87,20 @@ jobs:
             Execute these steps in order. If a step has no work, state that and continue to the next step.
             Post all review findings in a single summary comment only — never as inline PR review comments.
             </commitment>
+
+            <step name="triage">
+            Before doing any work, assess the PR scope:
+
+            1. Run `gh pr diff ${{ github.event.pull_request.number }} --name-only` to get changed files.
+            2. Classify as TRIVIAL if ALL changed files are:
+               - Config/CI files (.github/, .tessl/, *.toml, *.lock, *.json, *.yml, *.yaml)
+               - Documentation (*.md, docs/)
+               - Non-production code (demos/, experiments/, code_to_optimize/)
+               - Only whitespace, formatting, or comment changes
+
+            If TRIVIAL: post a single comment "No substantive code changes to review." and stop — do not execute any further steps.
+            Otherwise: continue with the full review below.
+            </step>
 
             <step name="lint_and_typecheck">
             Run checks on files changed in this PR and auto-fix what you can.


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to skip PR reviews for docs, config, CI, and non-production files
- Use `github.event.sender.login` instead of `github.actor` for reliable bot push detection on `synchronize` events
- Add triage step to early-exit on trivial PRs without running the full review pipeline