### PR TITLE
fix: relativize worktree paths in subagent optimization output

### DIFF
--- a/codeflash/cli_cmds/console.py
+++ b/codeflash/cli_cmds/console.py
@@ -418,15 +418,18 @@ def subagent_log_optimization_result(
     from codeflash.code_utils.time_utils import humanize_runtime
     from codeflash.models.test_type import TestType
 
+    def relativize(p: Path) -> str:
+        if project_root is not None:
+            with contextlib.suppress(ValueError):
+                return str(p.relative_to(project_root))
+        return str(p)
+
     diff_parts = []
     for path in original_code:
         old = original_code.get(path, "")
         new = new_code.get(path, "")
         if old != new:
-            display_path = str(path)
-            if project_root is not None:
-                with contextlib.suppress(ValueError):
-                    display_path = str(path.relative_to(project_root))
+            display_path = relativize(path)
             diff = unified_diff_strings(old, new, fromfile=display_path, tofile=display_path)
             if diff:
                 diff_parts.append(diff)
@@ -457,7 +460,7 @@ def subagent_log_optimization_result(
     xml = [
         "<codeflash-optimization>",
         f"  <function>{escape(function_name)}</function>",
-        f"  <file>{escape(str(file_path))}</file>",
+        f"  <file>{escape(relativize(file_path))}</file>",
         f"  <performance>{escape(perf_improvement_line)}</performance>",
         f"  <original-runtime>{escape(original_runtime)}</original-runtime>",
         f"  <optimized-runtime>{escape(optimized_runtime)}</optimized-runtime>",
@@ -472,7 +475,7 @@ def subagent_log_optimization_result(
         xml.append(f"  <diff>{escape(diff_str)}</diff>")
     for path in new_code:
         if new_code[path] != original_code.get(path, ""):
-            xml.append(f'  <optimized-code file="{escape(str(path))}">{escape(new_code[path])}</optimized-code>')
+            xml.append(f'  <optimized-code file="{escape(relativize(path))}">{escape(new_code[path])}</optimized-code>')
     xml.append("  <action>")
     xml.append("    1. Review the diff and optimized code yourself. Write a brief assessment (2-3 sentences) covering:")
     xml.append("       - Whether the optimization is correct and preserves behavior")


### PR DESCRIPTION
## Summary
- Fixed `<file>` and `<optimized-code file="...">` XML tags in subagent mode showing absolute worktree paths (e.g., `/tmp/codeflash/worktrees/myproject-20260309-123456/src/module.py`) instead of relative project paths (e.g., `src/module.py`)
- Extracted a `relativize()` helper in `subagent_log_optimization_result` and applied it consistently to all path outputs (diff headers, `<file>`, and `<optimized-code>` tags)

## Test plan
- [ ] Run optimization in subagent + worktree mode and verify diff output shows relative paths
- [ ] Run optimization in subagent mode without worktree and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)