### PR TITLE
chore: release v0.20.2

### DIFF
--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,2 +1,2 @@
 # These version placeholders will be replaced by uv-dynamic-versioning during build.
-__version__ = "0.20.1"
+__version__ = "0.20.2"


### PR DESCRIPTION
Bump version to 0.20.2 to trigger a PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)