### PR TITLE
fix: attempt to fix failing CI on codeflash optimization PRs before closing

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -198,12 +198,20 @@ jobs:
 
             For each PR:
             - If CI passes and the PR is mergeable → merge with `--squash --delete-branch`
-            - Close the PR as stale if ANY of these apply:
+            - If CI is failing:
+              1. Check out the PR branch and inspect the failing tests
+              2. Attempt to fix the failures (the optimization may have broken tests or introduced issues)
+              3. If fixed: commit, push, and leave a comment explaining what was fixed
+              4. If unfixable: close with `gh pr close <number> --comment "Closing: CI checks are failing — <describe the specific failures and why they can't be auto-fixed>." --delete-branch`
+            - Close the PR (without attempting fixes) if ANY of these apply:
               - Older than 7 days
               - Has merge conflicts (mergeable state is "CONFLICTING")
-              - CI is failing
               - The optimized function no longer exists in the target file (check the diff)
-              Close with: `gh pr close <number> --comment "Closing stale optimization PR." --delete-branch`
+              Close with: `gh pr close <number> --comment "<reason>" --delete-branch`
+              where <reason> explains WHY the PR is being closed. Examples:
+              - "Closing: PR is older than 7 days without being merged."
+              - "Closing: merge conflicts with the target branch."
+              - "Closing: the optimized function no longer exists in the target file."
             </step>
 
             <verification>


### PR DESCRIPTION
## Summary
- When CI fails on a codeflash-ai[bot] optimization PR, Claude now attempts to fix the failing tests before closing
- Close comments now include the specific reason instead of a generic "Closing stale optimization PR" message

Context: https://github.com/codeflash-ai/codeflash/pull/1782 was closed prematurely with no explanation when the fix was potentially straightforward.