### PR TITLE
fix: ensure worktree cleanup on SIGTERM, SIGHUP, and atexit

### DIFF
--- a/codeflash/code_utils/git_worktree_utils.py
+++ b/codeflash/code_utils/git_worktree_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import configparser
+import os
 import shutil
 import stat
 import subprocess
@@ -65,6 +66,10 @@ def create_detached_worktree(module_root: Path) -> Optional[Path]:
 
     repository.git.worktree("add", "-d", str(worktree_dir))
 
+    # Write PID file so stale worktrees can be detected after SIGKILL
+    pid_file = worktree_dir / ".codeflash.pid"
+    pid_file.write_text(str(os.getpid()), encoding="utf-8")
+
     # Get uncommitted diff from the original repo
     repository.git.add("-N", ".")  # add the index for untracked files to be included in the diff
     exclude_binary_files = [":!*.pyc", ":!*.pyo", ":!*.pyd", ":!*.so", ":!*.dll", ":!*.whl", ":!*.egg", ":!*.egg-info", ":!*.pyz", ":!*.pkl", ":!*.pickle", ":!*.joblib", ":!*.npy", ":!*.npz", ":!*.h5", ":!*.hdf5", ":!*.pth", ":!*.pt", ":!*.pb", ":!*.onnx", ":!*.db", ":!*.sqlite", ":!*.sqlite3", ":!*.feather", ":!*.parquet", ":!*.jpg", ":!*.jpeg", ":!*.png", ":!*.gif", ":!*.bmp", ":!*.tiff", ":!*.webp", ":!*.wav", ":!*.mp3", ":!*.ogg", ":!*.flac", ":!*.mp4", ":!*.avi", ":!*.mov", ":!*.mkv", ":!*.pdf", ":!*.doc", ":!*.docx", ":!*.xls", ":!*.xlsx", ":!*.ppt", ":!*.pptx", ":!*.zip", ":!*.rar", ":!*.tar", ":!*.tar.gz", ":!*.tgz", ":!*.bz2", ":!*.xz"]  # fmt: off
@@ -117,6 +122,36 @@ def remove_worktree(worktree_dir: Path) -> None:
         logger.debug(f"Removed worktree: {worktree_dir}")
     except Exception:
         logger.exception(f"Failed to remove worktree: {worktree_dir}")
+
+
+def is_process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # process exists but we can't signal it
+    return True
+
+
+def cleanup_stale_worktrees() -> None:
+    """Remove worktrees left behind by killed processes (e.g. SIGKILL)."""
+    if not worktree_dirs.exists():
+        return
+    for entry in worktree_dirs.iterdir():
+        if not entry.is_dir():
+            continue
+        pid_file = entry / ".codeflash.pid"
+        if pid_file.exists():
+            try:
+                pid = int(pid_file.read_text(encoding="utf-8").strip())
+            except (ValueError, OSError):
+                pid = None
+            if pid is not None and is_process_alive(pid):
+                continue  # worktree is still in use
+        # No PID file or owning process is dead — stale worktree
+        logger.info(f"Removing stale worktree: {entry}")
+        remove_worktree(entry)
 
 
 def create_diff_patch_from_worktree(

--- a/codeflash/optimization/optimizer.py
+++ b/codeflash/optimization/optimizer.py
@@ -22,6 +22,7 @@ from codeflash.code_utils.code_utils import cleanup_paths, get_run_tmp_file
 from codeflash.code_utils.env_utils import get_pr_number, is_pr_draft
 from codeflash.code_utils.git_utils import check_running_in_git_repo, git_root_dir
 from codeflash.code_utils.git_worktree_utils import (
+    cleanup_stale_worktrees,
     create_detached_worktree,
     create_diff_patch_from_worktree,
     create_worktree_snapshot_commit,
@@ -737,6 +738,8 @@ def mirror_path(path: Path, src_root: Path, dest_root: Path) -> Path:
 def run_with_args(args: Namespace) -> None:
     import atexit
     import signal
+
+    cleanup_stale_worktrees()
 
     optimizer = None
     original_sigterm = signal.getsignal(signal.SIGTERM)


### PR DESCRIPTION
## Summary

Ensures the git worktree is always cleaned up when running with `--worktree`, regardless of how the process exits:

- **Signal handlers** for `SIGTERM`, `SIGHUP`, `SIGQUIT`, and `SIGPIPE` — covers `kill`, Docker/systemd stop, terminal close, broken pipe, and `Ctrl+\`
- **`atexit` handler** as a safety net for unhandled exceptions and `sys.exit()` from elsewhere
- **`KeyboardInterrupt`** (`Ctrl+C`) — already handled, unchanged
- **Stale worktree cleanup at startup** — writes a `.codeflash.pid` file when creating a worktree; on next run, scans the worktrees directory and removes any whose owning process is dead (handles `SIGKILL` / `kill -9`)

Signal handlers and atexit registration are restored/unregistered in a `finally` block to avoid side effects outside the optimizer run.

## Test plan

- [x] Existing `tests/test_worktree.py` passes
- [x] Ruff lint passes
- [x] Manual: run with `--worktree`, send `SIGTERM` — verify worktree directory is removed
- [x] Manual: run with `--worktree`, close terminal (`SIGHUP`) — verify worktree directory is removed
- [x] Manual: run with `--worktree`, `Ctrl+C` — verify worktree directory is removed (existing behavior)
- [x] Manual: run with `--worktree`, `kill -9` — verify worktree is cleaned up on next run
- [x] Manual: run two concurrent `--worktree` processes, `kill -9` one — verify only the killed process's worktree is cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)