### PR TITLE
fix: include codeflash.toml in config resolution depth comparison

### DIFF
--- a/codeflash/code_utils/config_parser.py
+++ b/codeflash/code_utils/config_parser.py
@@ -96,19 +96,28 @@ def parse_config_file(
 ) -> tuple[dict[str, Any], Path]:
     package_json_path = find_package_json(config_file_path)
     pyproject_toml_path = find_closest_config_file("pyproject.toml") if config_file_path is None else None
+    codeflash_toml_path = find_closest_config_file("codeflash.toml") if config_file_path is None else None
+
+    # Pick the closest toml config (pyproject.toml or codeflash.toml).
+    # Java projects use codeflash.toml; Python projects use pyproject.toml.
+    closest_toml_path = None
+    if pyproject_toml_path and codeflash_toml_path:
+        closest_toml_path = max(pyproject_toml_path, codeflash_toml_path, key=lambda p: len(p.parent.parts))
+    else:
+        closest_toml_path = pyproject_toml_path or codeflash_toml_path
 
     # When both config files exist, prefer the one closer to CWD.
     # This prevents a parent-directory package.json (e.g., monorepo root)
-    # from overriding a closer pyproject.toml with [tool.codeflash].
+    # from overriding a closer pyproject.toml or codeflash.toml.
     use_package_json = False
     if package_json_path:
-        if pyproject_toml_path is None:
+        if closest_toml_path is None:
             use_package_json = True
         else:
             # Compare depth: more path parts = closer to CWD = more specific
             package_json_depth = len(package_json_path.parent.parts)
-            pyproject_toml_depth = len(pyproject_toml_path.parent.parts)
-            use_package_json = package_json_depth >= pyproject_toml_depth
+            toml_depth = len(closest_toml_path.parent.parts)
+            use_package_json = package_json_depth >= toml_depth
 
     if use_package_json:
         assert package_json_path is not None


### PR DESCRIPTION
## Problems fixed

When a `package.json` exists in a parent directory (e.g., monorepo root or dev dependency), `parse_config_file()` would always prefer it over a closer `codeflash.toml` in the current project directory. This caused Java projects to resolve the wrong `module_root` and `project_root`, leading to:

- Generated tests written to the wrong directory
- Maven invoked from the wrong `cwd` (no `pom.xml` → build failure)
- Maven Central runtime JAR resolution failing (because `dependency:resolve` also needs a valid `pom.xml` in the working directory)

## Root cause

The depth comparison in `parse_config_file()` only checked `package.json` against `pyproject.toml`. Java projects use `codeflash.toml`, which was never included in the comparison. When `pyproject_toml_path` was `None` (no `pyproject.toml` exists), the code unconditionally set `use_package_json = True` — regardless of whether a closer `codeflash.toml` existed.

## Solution

Find the closest toml config file (either `pyproject.toml` or `codeflash.toml`) and use that in the depth comparison against `package.json`. A closer `codeflash.toml` now correctly takes priority over a farther `package.json`.

## Code changes

- **`codeflash/code_utils/config_parser.py`**: Added `codeflash.toml` lookup via `find_closest_config_file()`, pick the closer of `pyproject.toml` / `codeflash.toml`, and compare that against `package.json` depth.

## Testing

- All 145 setup tests pass (`tests/test_setup/` — 22 config + 65 detector + 29 e2e + 29 first_run)
- Verified manually:
  - Java project with `codeflash.toml` + parent `package.json` → now correctly resolves `codeflash.toml`
  - JS project with `package.json` → still resolves `package.json` (unchanged)
  - Python project with `pyproject.toml` → still resolves `pyproject.toml` (unchanged)
- Full E2E Fibonacci optimization passed with fix applied

## Impact

- Java projects nested inside repos with `package.json` (e.g., dev testing) now work correctly
- No behavior change for JavaScript or Python projects