### PR TITLE
fix: restore version to 0.20.2 after omni-java merge

### DIFF
--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,2 +1,2 @@
 # These version placeholders will be replaced by uv-dynamic-versioning during build.
-__version__ = "0.20.1.post872.dev0+d7ab5a98"
+__version__ = "0.20.2"


### PR DESCRIPTION
The omni-java merge (PR #1199) overwrote `version.py` with a dev version (`0.20.1.post872.dev0+d7ab5a98`). This restores it to `0.20.2`.