### PR TITLE
chore: release v0.20.3

### DIFF
--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,2 +1,2 @@
 # These version placeholders will be replaced by uv-dynamic-versioning during build.
-__version__ = "0.20.2"
+__version__ = "0.20.3"


### PR DESCRIPTION
Bump version to 0.20.3 to trigger a PyPI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)