### PR TITLE
fix: filter Java runtime annotations by class name and fix ordering

### DIFF
--- a/codeflash/languages/function_optimizer.py
+++ b/codeflash/languages/function_optimizer.py
@@ -2426,9 +2426,6 @@ class FunctionOptimizer:
             else "Coverage data not available"
         )
 
-        generated_tests = self.language_support.remove_test_functions_from_generated_tests(
-            generated_tests, test_functions_to_remove
-        )
         map_gen_test_file_to_no_of_tests = original_code_baseline.behavior_test_results.file_to_no_of_tests(
             test_functions_to_remove
         )
@@ -2438,8 +2435,15 @@ class FunctionOptimizer:
             best_optimization.winning_benchmarking_test_results.usable_runtime_data_by_test_case()
         )
 
+        # Add runtime comments BEFORE removing test functions, so line numbers from
+        # instrumentation match the original source. Removing functions afterward
+        # correctly shifts annotations along with their associated lines.
         generated_tests = self.language_support.add_runtime_comments_to_generated_tests(
             generated_tests, original_runtime_by_test, optimized_runtime_by_test, self.test_cfg.tests_project_rootdir
+        )
+
+        generated_tests = self.language_support.remove_test_functions_from_generated_tests(
+            generated_tests, test_functions_to_remove
         )
 
         generated_tests_str = ""

--- a/codeflash/languages/java/replacement.py
+++ b/codeflash/languages/java/replacement.py
@@ -873,15 +873,35 @@ def add_runtime_comments(
     if not original_runtimes or not optimized_runtimes:
         return test_source
 
+    # Extract class names declared in this test source to filter runtime keys.
+    # Only annotations whose "ClassName.method" prefix references a class in this file should be applied.
+    source_class_names: set[str] = set()
+    for source_line in test_source.splitlines():
+        stripped_line = source_line.strip()
+        if stripped_line.startswith(("public class ", "class ")):
+            # Extract class name: "public class FooTest {" -> "FooTest"
+            parts = stripped_line.split()
+            class_idx = parts.index("class") + 1 if "class" in parts else -1
+            if 0 < class_idx < len(parts):
+                class_name = parts[class_idx].rstrip("{").strip()
+                if class_name:
+                    source_class_names.add(class_name)
+
     # Build a map of line_number -> (original_ns, optimized_ns) from runtime keys.
     # Keys look like "ClassName.methodName#L15" — extract the line number after "#L".
+    # Only include keys whose class name matches a class declared in this source file.
     line_runtimes: dict[int, tuple[int, int]] = {}
     for key in original_runtimes:
         if "#L" not in key:
             continue
-        line_str = key.split("#L", 1)[1]
+        prefix, line_part = key.split("#L", 1)
+        # Filter by class name: prefix is "ClassName.methodName", extract the class
+        if source_class_names:
+            key_class = prefix.split(".")[0] if "." in prefix else prefix
+            if key_class not in source_class_names:
+                continue
         try:
-            line_num = int(line_str)
+            line_num = int(line_part)
         except ValueError:
             continue
         orig_ns = original_runtimes[key]

--- a/tests/test_languages/test_java/test_java_runtime_comments.py
+++ b/tests/test_languages/test_java/test_java_runtime_comments.py
@@ -135,6 +135,71 @@ public class FibTest {
         result = add_runtime_comments(source, original, optimized)
         assert result == source
 
+    def test_annotations_only_for_matching_classes(self) -> None:
+        """Bug: add_runtime_comments ignores class/method prefixes and only uses line numbers.
+
+        When runtime keys from different test classes map to the same line number,
+        annotations from unrelated classes leak into the source. Only annotations
+        whose class.method prefix matches a class in the test source should be applied.
+        """
+        source = """\
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+public class FibTest {
+    @Test
+    void testSmall() {
+        Fibonacci.fibonacci(5);
+    }
+}
+"""
+        # Keys from FibTest should match, keys from UnrelatedTest should NOT
+        original = {
+            "FibTest.testSmall#L8": 500_000,
+            "UnrelatedTest.testOther#L8": 2_000_000,  # same line number, different class
+        }
+        optimized = {"FibTest.testSmall#L8": 50_000, "UnrelatedTest.testOther#L8": 200_000}
+        result = add_runtime_comments(source, original, optimized)
+        # Only FibTest annotation should appear, NOT the summed value from both classes
+        expected = """\
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+public class FibTest {
+    @Test
+    void testSmall() {
+        Fibonacci.fibonacci(5); // 500\u03bcs -> 50.0\u03bcs (900% faster)
+    }
+}
+"""
+        assert result == expected
+
+    def test_annotations_different_classes_different_lines_no_leak(self) -> None:
+        """Annotations from classes not present in the source should not appear at all."""
+        source = """\
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+public class AlphaTest {
+    @Test
+    void testAlpha() {
+        Alpha.run();
+    }
+}
+"""
+        # BetaTest.testBeta#L10 should not annotate line 10 in AlphaTest source
+        original = {"AlphaTest.testAlpha#L8": 1_000_000, "BetaTest.testBeta#L10": 3_000_000}
+        optimized = {"AlphaTest.testAlpha#L8": 100_000, "BetaTest.testBeta#L10": 300_000}
+        result = add_runtime_comments(source, original, optimized)
+        lines = result.splitlines()
+        # Line 10 (1-indexed) = line 9 (0-indexed) = "}" - should NOT have annotation
+        assert "//" not in lines[9]
+        # Line 8 should have the AlphaTest annotation
+        assert "// 1.00ms -> 100\u03bcs" in lines[7]
+
     def test_same_line_sums_runtimes(self) -> None:
         source = """\
 package com.example;
@@ -166,6 +231,162 @@ public class FibTest {
 }
 """
         assert result == expected
+
+
+class TestAddRuntimeCommentsToGeneratedTests:
+    """Tests for add_runtime_comments_to_generated_tests on JavaSupport."""
+
+    def test_multi_file_annotations_dont_leak(self) -> None:
+        """Bug: annotations from one test file should not appear in another test file.
+
+        When multiple test files have different classes, the runtime map from file 1
+        should not affect file 2. Currently, all runtime keys are merged into one map
+        and applied to every file, causing cross-file annotation leaking.
+        """
+        from pathlib import Path
+        from unittest.mock import MagicMock
+
+        from codeflash.languages.java.support import JavaSupport
+        from codeflash.models.models import GeneratedTests, GeneratedTestsList, InvocationId
+
+        support = MagicMock(spec=JavaSupport)
+        support._build_runtime_map = JavaSupport._build_runtime_map.__get__(support, JavaSupport)
+        support.add_runtime_comments = JavaSupport.add_runtime_comments.__get__(support, JavaSupport)
+        support._analyzer = None
+        support.add_runtime_comments_to_generated_tests = JavaSupport.add_runtime_comments_to_generated_tests.__get__(
+            support, JavaSupport
+        )
+
+        test1_source = """\
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+public class FooTest {
+    @Test
+    void testFoo() {
+        Foo.run();
+    }
+}
+"""
+        test2_source = """\
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+public class FooTest_2 {
+    @Test
+    void testFoo2() {
+        Foo.run2();
+    }
+}
+"""
+        generated_tests = GeneratedTestsList(
+            generated_tests=[
+                GeneratedTests(
+                    generated_original_test_source=test1_source,
+                    instrumented_behavior_test_source="",
+                    instrumented_perf_test_source="",
+                    behavior_file_path=Path("FooTest.java"),
+                    perf_file_path=Path("FooTest_perf.java"),
+                ),
+                GeneratedTests(
+                    generated_original_test_source=test2_source,
+                    instrumented_behavior_test_source="",
+                    instrumented_perf_test_source="",
+                    behavior_file_path=Path("FooTest_2.java"),
+                    perf_file_path=Path("FooTest_2_perf.java"),
+                ),
+            ]
+        )
+
+        # Runtime data: FooTest has call at L8, FooTest_2 has call at L8 too
+        inv_id_1 = InvocationId(
+            test_module_path="com.example",
+            test_class_name="FooTest",
+            test_function_name="testFoo",
+            function_getting_tested="run",
+            iteration_id="L8_1",
+        )
+        inv_id_2 = InvocationId(
+            test_module_path="com.example",
+            test_class_name="FooTest_2",
+            test_function_name="testFoo2",
+            function_getting_tested="run2",
+            iteration_id="L8_1",
+        )
+
+        original = {inv_id_1: [1_000_000], inv_id_2: [2_000_000]}
+        optimized = {inv_id_1: [100_000], inv_id_2: [200_000]}
+
+        result = support.add_runtime_comments_to_generated_tests(generated_tests, original, optimized)
+
+        result_test1 = result.generated_tests[0].generated_original_test_source
+        result_test2 = result.generated_tests[1].generated_original_test_source
+
+        # Test file 1 should have FooTest annotation ONLY (1ms -> 100us)
+        assert "// 1.00ms -> 100\u03bcs" in result_test1
+        assert "// 2.00ms -> 200\u03bcs" not in result_test1  # FooTest_2 annotation should NOT appear
+
+        # Test file 2 should have FooTest_2 annotation ONLY (2ms -> 200us)
+        assert "// 2.00ms -> 200\u03bcs" in result_test2
+        assert "// 1.00ms -> 100\u03bcs" not in result_test2  # FooTest annotation should NOT appear
+
+
+class TestRuntimeCommentsAfterFunctionRemoval:
+    """Tests that runtime comments remain correct when test functions are removed."""
+
+    def test_removal_after_annotation_preserves_line_alignment(self) -> None:
+        """Bug: when test functions are removed BEFORE adding runtime comments,
+        line numbers shift and annotations end up on wrong lines.
+
+        The fix is to add runtime comments first, then remove test functions.
+        This test verifies the correct ordering by simulating both operations.
+        """
+        from codeflash.languages.java.replacement import add_runtime_comments, remove_test_functions
+
+        source = """\
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+public class FibTest {
+    @Test
+    void testFailing() {
+        Fibonacci.fibonacci(0);
+    }
+
+    @Test
+    void testWorking() {
+        Fibonacci.fibonacci(100);
+    }
+}
+"""
+        original = {"FibTest.testWorking#L13": 10_000_000}
+        optimized = {"FibTest.testWorking#L13": 1_000_000}
+
+        # Correct order: annotate THEN remove
+        annotated = add_runtime_comments(source, original, optimized)
+        result_correct = remove_test_functions(annotated, ["testFailing"])
+        # The annotation should be on the Fibonacci.fibonacci(100) line
+        for line in result_correct.splitlines():
+            if "Fibonacci.fibonacci(100)" in line:
+                assert "// 10.0ms -> 1.00ms" in line, f"Annotation missing from call line: {line}"
+                break
+        else:
+            raise AssertionError("Fibonacci.fibonacci(100) line not found in result")
+
+        # Wrong order (old behavior): remove THEN annotate - annotation lands on wrong line
+        removed_first = remove_test_functions(source, ["testFailing"])
+        result_wrong = add_runtime_comments(removed_first, original, optimized)
+        # After removal, testFailing (lines 7-9) is gone, shifting testWorking up.
+        # Line 13 in the post-removal source is beyond the file end or on a wrong line.
+        # Verify the annotation does NOT correctly land on the fibonacci(100) call
+        for line in result_wrong.splitlines():
+            if "Fibonacci.fibonacci(100)" in line:
+                has_annotation = "// 10.0ms -> 1.00ms" in line
+                assert not has_annotation, "Wrong ordering accidentally worked - test needs different line numbers"
+                break
 
 
 class TestBuildRuntimeMap:


### PR DESCRIPTION
Runtime annotations in PR descriptions were broken in two ways:
1. add_runtime_comments() ignored class/method prefixes in keys, causing annotations from unrelated test classes to leak across files and sum incorrectly at the same line number. Now filters by class names found in each test source file.
2. Test functions were removed before annotations were added, shifting line numbers so annotations landed on wrong lines. Swapped ordering so annotations are applied first, then function removal carries them along correctly.