### PR TITLE
fix: output structured XML errors in subagent mode

### DIFF
--- a/codeflash/code_utils/code_utils.py
+++ b/codeflash/code_utils/code_utils.py
@@ -17,7 +17,7 @@ import tomlkit
 
 from codeflash.cli_cmds.console import logger, paneled_text
 from codeflash.code_utils.config_parser import find_pyproject_toml, get_all_closest_config_files
-from codeflash.lsp.helpers import is_LSP_enabled
+from codeflash.lsp.helpers import is_LSP_enabled, is_subagent_mode
 
 _INVALID_CHARS_NT = {"<", ">", ":", '"', "|", "?", "*"}
 
@@ -458,6 +458,11 @@ def exit_with_message(message: str, *, error_on_exit: bool = False) -> None:
     if is_LSP_enabled():
         logger.error(message)
         return
+    if is_subagent_mode():
+        from xml.sax.saxutils import escape
+
+        sys.stdout.write(f"<codeflash-error>{escape(message)}</codeflash-error>\n")
+        sys.exit(1 if error_on_exit else 0)
     paneled_text(message, panel_args={"style": "red"})
 
     sys.exit(1 if error_on_exit else 0)

--- a/tests/test_code_utils.py
+++ b/tests/test_code_utils.py
@@ -8,6 +8,7 @@ import pytest
 
 from codeflash.code_utils.code_utils import (
     cleanup_paths,
+    exit_with_message,
     file_name_from_test_module_name,
     file_path_from_module_name,
     get_all_function_names,
@@ -751,3 +752,33 @@ class MyClass:
 """
     result = validate_python_code(code)
     assert result == code
+
+
+class TestExitWithMessageSubagent:
+    @patch("codeflash.code_utils.code_utils.is_subagent_mode", return_value=True)
+    def test_outputs_structured_xml_in_subagent_mode(self, _mock_subagent: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            exit_with_message("Something went wrong", error_on_exit=True)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "<codeflash-error>" in captured.out
+        assert "Something went wrong" in captured.out
+        assert "</codeflash-error>" in captured.out
+
+    @patch("codeflash.code_utils.code_utils.is_subagent_mode", return_value=True)
+    def test_escapes_xml_special_chars(self, _mock_subagent: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            exit_with_message('File <foo> & "bar" not found', error_on_exit=True)
+        captured = capsys.readouterr()
+        assert "&lt;foo&gt;" in captured.out
+        assert "&amp;" in captured.out
+
+    @patch("codeflash.code_utils.code_utils.is_subagent_mode", return_value=False)
+    @patch("codeflash.code_utils.code_utils.is_LSP_enabled", return_value=False)
+    def test_no_xml_when_not_subagent(
+        self, _mock_lsp: MagicMock, _mock_subagent: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            exit_with_message("Normal error", error_on_exit=True)
+        captured = capsys.readouterr()
+        assert "<codeflash-error>" not in captured.out


### PR DESCRIPTION
## Summary

- `exit_with_message()` now outputs `<codeflash-error>` XML to stdout in subagent mode instead of Rich panel text
- Enables the Claude Code plugin agent to parse error messages programmatically

## Problem

When codeflash encounters errors in `--subagent` mode (no git repo, file not found, config errors, etc.), it outputs Rich-formatted panel text. The calling Claude agent expects structured data and may misinterpret or ignore these errors. The success path already outputs structured XML (`<codeflash-optimization>`, `<codeflash-summary>`), but the error path didn't.

## Root cause

`exit_with_message()` in `code_utils.py` is the central error exit function used by ~15 call sites. It had special handling for LSP mode (log instead of exit) but no handling for subagent mode.

## Solution

Added a subagent mode check in `exit_with_message()` that outputs structured XML before exiting:

```xml
<codeflash-error>No codeflash configuration found. Run `codeflash init` first.</codeflash-error>
```

XML special characters are properly escaped via `xml.sax.saxutils.escape`. This matches the pattern already used by the success output (`<codeflash-optimization>`) and the no-results output (`<codeflash-summary>`).

## Code changes

- **`codeflash/code_utils/code_utils.py`**: Added `is_subagent_mode` import and subagent check in `exit_with_message()` — 4 lines of logic
- **`tests/test_code_utils.py`**: 3 new tests covering structured XML output, XML escaping, and non-subagent mode behavior

## Testing

```bash
$ uv run pytest tests/test_code_utils.py::TestExitWithMessageSubagent -v
# 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)