### PR TITLE
fix: resolve test module path for JS when tests are outside tests_project_rootdir

### DIFF
--- a/codeflash/languages/function_optimizer.py
+++ b/codeflash/languages/function_optimizer.py
@@ -2105,9 +2105,14 @@ class FunctionOptimizer:
                         },
                     )
 
-                    test_module_path = Path(
-                        module_name_from_file_path(gt.behavior_file_path, self.test_cfg.tests_project_rootdir)
-                    )
+                    try:
+                        test_module_path = Path(
+                            module_name_from_file_path(gt.behavior_file_path, self.test_cfg.tests_project_rootdir)
+                        )
+                    except ValueError:
+                        test_module_path = Path(
+                            module_name_from_file_path(gt.behavior_file_path, self.test_cfg.project_root_path)
+                        )
                     repair_result = self.aiservice_client.repair_generated_tests(
                         test_source=gt.generated_original_test_source,
                         functions_to_repair=review.functions_to_repair,

--- a/codeflash/verification/verifier.py
+++ b/codeflash/verification/verifier.py
@@ -33,7 +33,11 @@ def generate_tests(
     # TODO: Sometimes this recreates the original Class definition. This overrides and messes up the original
     #  class import. Remove the recreation of the class definition
     start_time = time.perf_counter()
-    test_module_path = Path(module_name_from_file_path(test_path, test_cfg.tests_project_rootdir))
+    try:
+        test_module_path = Path(module_name_from_file_path(test_path, test_cfg.tests_project_rootdir))
+    except ValueError:
+        # For JS/TS, generated tests may be placed near the source file (not under tests_project_rootdir)
+        test_module_path = Path(module_name_from_file_path(test_path, test_cfg.project_root_path))
 
     # Detect module system via language support (non-None for JS/TS, None for Python)
     lang_support = current_language_support()

--- a/tests/test_code_utils.py
+++ b/tests/test_code_utils.py
@@ -99,6 +99,19 @@ def test_module_name_from_file_path_with_root_as_file() -> None:
     assert module_name == "code_utils"
 
 
+def test_module_name_from_file_path_not_under_root() -> None:
+    project_root_path = Path("/project/tests")
+    file_path = Path("/project/code_to_optimize/js/tests/codeflash-generated/test_calc.test.js")
+
+    with pytest.raises(ValueError, match="is not within the project root"):
+        module_name_from_file_path(file_path, project_root_path)
+
+    # But it should work with the actual project root
+    broader_root = Path("/project")
+    module_name = module_name_from_file_path(file_path, broader_root)
+    assert module_name == "code_to_optimize.js.tests.codeflash-generated.test_calc.test"
+
+
 def test_get_imports_from_file_with_file_path(tmp_path: Path) -> None:
     test_file = tmp_path / "test_file.py"
     test_file.write_text("import os\nfrom sys import path\n")


### PR DESCRIPTION
## Summary
- For JS projects, generated tests are placed near the source file (not under `tests_project_rootdir`), causing `module_name_from_file_path` to crash with `ValueError`
- Added fallback to `project_root_path` in `verifier.py` and `function_optimizer.py` when test path isn't under `tests_project_rootdir`
- Added unit test covering the path resolution failure and fallback

## Test plan
- [x] `test_module_name_from_file_path_not_under_root` passes
- [x] `codeflash --file code_to_optimize/js/code_to_optimize_js/calculator.js --module-root code_to_optimize --subagent` runs to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)