### PR TITLE
Clean up Java test skip markers

### DIFF
--- a/codeflash-benchmark/codeflash_benchmark/version.py
+++ b/codeflash-benchmark/codeflash_benchmark/version.py
@@ -1,2 +1,2 @@
 # These version placeholders will be replaced by uv-dynamic-versioning during build.
-__version__ = "0.20.5.post169.dev0+2dba3e38"
+__version__ = "0.20.5.post177.dev0+da536db8"

--- a/codeflash/version.py
+++ b/codeflash/version.py
@@ -1,2 +1,2 @@
 # These version placeholders will be replaced by uv-dynamic-versioning during build.
-__version__ = "0.20.5.post169.dev0+2dba3e38"
+__version__ = "0.20.5.post177.dev0+da536db8"

--- a/tests/test_languages/test_java/test_comparator.py
+++ b/tests/test_languages/test_java/test_comparator.py
@@ -1,6 +1,5 @@
 """Tests for Java test result comparison."""
 
-import shutil
 import sqlite3
 from pathlib import Path
 
@@ -15,7 +14,7 @@ from codeflash.languages.java.comparator import (
 from codeflash.models.models import TestDiffScope
 
 # Skip tests that require the codeflash-runtime JAR (built by Maven from codeflash-java-runtime/)
-requires_java = pytest.mark.skipif(
+requires_java_runtime = pytest.mark.skipif(
     _find_comparator_jar() is None,
     reason="codeflash-runtime JAR not found - skipping Comparator integration tests",
 )
@@ -451,7 +450,7 @@ class TestEdgeCases:
         assert equivalent is True
 
 
-@requires_java
+@requires_java_runtime
 class TestTestResultsTableSchema:
     """Tests for Java Comparator reading from test_results table schema.
 
@@ -926,7 +925,7 @@ class TestComparatorErrorHandling:
         assert diffs[0].scope == TestDiffScope.DID_PASS
 
 
-@requires_java
+@requires_java_runtime
 class TestComparatorJavaEdgeCases(TestTestResultsTableSchema):
     """Tests for Java Comparator edge cases that require Java runtime.
 

--- a/tests/test_languages/test_java/test_run_and_parse.py
+++ b/tests/test_languages/test_java/test_run_and_parse.py
@@ -377,7 +377,6 @@ public class AdderMultiTest {
         assert "testAddPositive" in test_names
         assert "testAddZero" in test_names
 
-    @requires_java_runtime
     def test_behavior_return_value_correctness(self, tmp_path):
         """Verify the Comparator JAR correctly identifies equivalent vs. differing results.
 


### PR DESCRIPTION
## Summary
- Remove dead `import shutil` from `test_comparator.py` (leftover from `shutil.which` → `_find_comparator_jar` change in #2047)
- Rename `requires_java` → `requires_java_runtime` in `test_comparator.py` for consistency with `test_run_and_parse.py`
- Remove redundant `@requires_java_runtime` on `test_behavior_return_value_correctness` — the class-level decorator already covers it

## Test plan
- [x] `pytest tests/test_languages/test_java/ -v` — 62 passed, 19 skipped, 0 failures