### PR TITLE
fix(ci): add shell: bash to conditional install step for Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
+        shell: bash
         run: |
           if [[ "${{ matrix.python-version }}" == "3.9" || "${{ matrix.python-version }}" == "3.13" ]]; then
             uv sync --group tests


### PR DESCRIPTION
## Summary

- The `if [[ ... ]]; then` bash syntax in the merged CI upgrade (#2052) fails on Windows runners which default to PowerShell
- Adding `shell: bash` to the conditional install step fixes the `ParserError: Missing '(' after 'if'` error

## Test plan

- [ ] Windows unit-tests (3.13) job passes