### PR TITLE
fix: increase API read timeout to prevent flaky E2E failures

### DIFF
--- a/codeflash/api/aiservice.py
+++ b/codeflash/api/aiservice.py
@@ -47,7 +47,9 @@ class AiServiceClient:
         self.headers = {"Authorization": f"Bearer {get_codeflash_api_key()}", "Connection": "close"}
         self.llm_call_counter = count(1)
         self.is_local = self.base_url == "http://localhost:8000"
-        self.timeout: float | None = 300 if self.is_local else 90
+        # (connect_timeout, read_timeout) — connect should be fast; read
+        # can be slow because the server runs LLM inference.
+        self.timeout: float | tuple[float, float] | None = (10, 300)
 
     def get_next_sequence(self) -> int:
         """Get the next LLM call sequence number."""
@@ -88,7 +90,7 @@ class AiServiceClient:
         endpoint: str,
         method: str = "POST",
         payload: dict[str, Any] | list[dict[str, Any]] | None = None,
-        timeout: float | None = None,
+        timeout: float | tuple[float, float] | None = None,
     ) -> requests.Response:
         """Make an API request to the given endpoint on the AI service.
 


### PR DESCRIPTION
## Summary

- Increase API read timeout from 90s to 300s for all `app.codeflash.ai` endpoints
- Split into `(connect=10s, read=300s)` tuple so connections fail fast but LLM inference gets adequate time
- Fixes flaky `async-optimization` E2E test caused by `ReadTimeoutError` on `/testgen` endpoint under load

## Root cause

`AiServiceClient` used a flat `timeout=90` for prod, passed to every `requests.post()` call. LLM-powered endpoints (`/testgen`, `/optimize`, `/refinement`, etc.) can legitimately exceed 90s when the backend is under load. When hit, the request raises `ReadTimeoutError`, test generation returns `None`, and the E2E test fails.

## Test plan

- [ ] CI passes (unit tests, type-check)
- [ ] `async-optimization` E2E test no longer flakes on timeout