### PR TITLE
fix: detect JUnit 5 from submodule build files and default to JUnit 5

### DIFF
--- a/codeflash/languages/java/config.py
+++ b/codeflash/languages/java/config.py
@@ -163,9 +163,9 @@ def _detect_test_framework(project_root: Path, build_tool: BuildTool) -> tuple[s
         logger.debug("Selected TestNG as test framework")
         return "testng", has_junit5, has_junit4, has_testng
 
-    # Default to JUnit 4 if nothing detected (more common in legacy projects)
-    logger.debug("No test framework detected, defaulting to JUnit 4")
-    return "junit4", has_junit5, has_junit4, has_testng
+    # Default to JUnit 5 if nothing detected (standard since 2017)
+    logger.debug("No test framework detected, defaulting to JUnit 5")
+    return "junit5", has_junit5, has_junit4, has_testng
 
 
 def _detect_test_deps_from_pom(project_root: Path) -> tuple[bool, bool, bool]:
@@ -285,6 +285,23 @@ def _detect_test_deps_from_gradle(project_root: Path) -> tuple[bool, bool, bool]
                     has_testng = True
             except Exception:
                 pass
+
+    # For multi-module projects, check submodule build files if root has no test deps
+    if not (has_junit5 or has_junit4 or has_testng):
+        for sub_gradle in sorted(project_root.glob("*/build.gradle*")):
+            if sub_gradle.name in ("build.gradle", "build.gradle.kts"):
+                try:
+                    content = sub_gradle.read_text(encoding="utf-8")
+                    if "junit-jupiter" in content or "useJUnitPlatform" in content:
+                        has_junit5 = True
+                    if "junit:junit" in content:
+                        has_junit4 = True
+                    if "testng" in content.lower():
+                        has_testng = True
+                    if has_junit5:
+                        break  # JUnit 5 found, no need to check more
+                except Exception:
+                    pass
 
     return has_junit5, has_junit4, has_testng
 

--- a/tests/test_languages/test_java/test_config.py
+++ b/tests/test_languages/test_java/test_config.py
@@ -7,6 +7,8 @@ import pytest
 from codeflash.languages.java.build_tools import BuildTool
 from codeflash.languages.java.config import (
     JavaProjectConfig,
+    _detect_test_deps_from_gradle,
+    _detect_test_framework,
     detect_java_project,
     get_test_class_pattern,
     get_test_file_pattern,
@@ -342,3 +344,50 @@ class TestDetectWithFixture:
         assert config.source_root is not None
         assert config.test_root is not None
         assert config.has_junit5 is True
+
+
+class TestGradleSubmoduleDetection:
+
+    def test_detect_gradle_junit5_from_submodule(self, tmp_path: Path) -> None:
+        root = tmp_path.resolve()
+        # Root build.gradle with no test deps
+        (root / "build.gradle.kts").write_text("plugins { java }\n", encoding="utf-8")
+        (root / "settings.gradle.kts").write_text('include("submodule-a")\n', encoding="utf-8")
+
+        # Submodule with JUnit 5
+        sub = root / "submodule-a"
+        sub.mkdir()
+        (sub / "build.gradle.kts").write_text(
+            'dependencies { testImplementation("org.junit.jupiter:junit-jupiter:5.10.0") }\n'
+            "tasks.withType<Test> { useJUnitPlatform() }\n",
+            encoding="utf-8",
+        )
+
+        has_junit5, has_junit4, has_testng = _detect_test_deps_from_gradle(root)
+        assert has_junit5 is True
+        assert has_junit4 is False
+        assert has_testng is False
+
+    def test_detect_gradle_junit5_from_root(self, tmp_path: Path) -> None:
+        root = tmp_path.resolve()
+        (root / "build.gradle").write_text(
+            "dependencies { testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0' }\n"
+            "test { useJUnitPlatform() }\n",
+            encoding="utf-8",
+        )
+
+        has_junit5, has_junit4, has_testng = _detect_test_deps_from_gradle(root)
+        assert has_junit5 is True
+        assert has_junit4 is False
+        assert has_testng is False
+
+    def test_default_to_junit5_when_nothing_detected(self, tmp_path: Path) -> None:
+        root = tmp_path.resolve()
+        # Empty Gradle project — no test deps anywhere
+        (root / "build.gradle.kts").write_text("plugins { java }\n", encoding="utf-8")
+
+        framework, has_junit5, has_junit4, has_testng = _detect_test_framework(root, BuildTool.GRADLE)
+        assert framework == "junit5"
+        assert has_junit5 is False
+        assert has_junit4 is False
+        assert has_testng is False


### PR DESCRIPTION
## Problem

Multi-module Gradle projects (OpenRewrite, Spring, etc.) were misdetected as JUnit 4 projects. The AI service then generated JUnit 4 tests that failed to compile because the project only has JUnit 5 dependencies.

## Root Cause

`_detect_test_deps_from_gradle()` in `config.py` only checked the root `build.gradle(.kts)`. For multi-module projects, the root build file typically only has plugin declarations — JUnit dependencies are in module-level build files.

Secondary: the default framework was `junit4`, which is wrong for the vast majority of modern Java projects.

## Fix

1. After checking the root build file, scan immediate child directories for `build.gradle(.kts)` files
2. Changed the default framework from `junit4` to `junit5` (JUnit 5 has been the standard since 2017)

## Test Coverage

- 3 new tests in `TestGradleSubmoduleDetection`:
  - `test_detect_gradle_junit5_from_submodule`: Multi-module with junit-jupiter in submodule only
  - `test_detect_gradle_junit5_from_root`: Single-module with junit-jupiter in root (regression check)
  - `test_default_to_junit5_when_nothing_detected`: Empty project defaults to junit5

## Testing

```
$ uv run pytest tests/test_languages/test_java/test_config.py::TestGradleSubmoduleDetection -v
3 passed
```

All 21 existing config tests still pass (18 existing + 3 new).