### PR TITLE
Refactor: collect_setup_info in cmd_init to reduce complexity and isolate setup steps

### DIFF
--- a/codeflash/cli_cmds/cmd_init.py
+++ b/codeflash/cli_cmds/cmd_init.py
@@ -149,18 +149,47 @@ def ask_run_end_to_end_test(args: Namespace) -> None:
         run_end_to_end_test(args, file_path)
 
 
-def collect_setup_info() -> CLISetupInfo:
-    from git import InvalidGitRepositoryError, Repo
-
-    curdir = Path.cwd()
-    # Check if the cwd is writable
+def _ensure_current_directory_is_writable(curdir: Path) -> None:
     if not os.access(curdir, os.W_OK):
         click.echo(f"❌ The current directory isn't writable, please check your folder permissions and try again.{LF}")
         click.echo("It's likely you don't have write permissions for this folder.")
         sys.exit(1)
 
-    # Check for the existence of pyproject.toml or setup.py
-    project_name = check_for_toml_or_setup_file()
+
+def _prompt_for_custom_relative_directory(*, panel_title: str, panel_body: str, answer_name: str, message: str) -> Path:
+    custom_panel = Panel(
+        Text(panel_body, style="yellow"),
+        title=panel_title,
+        border_style="bright_yellow",
+    )
+    console.print(custom_panel)
+    console.print()
+
+    while True:
+        custom_questions = [
+            inquirer.Path(
+                answer_name,
+                message=message,
+                path_type=inquirer.Path.DIRECTORY,
+                exists=True,
+            )
+        ]
+
+        custom_answers = inquirer.prompt(custom_questions, theme=CodeflashTheme())
+        if not custom_answers:
+            apologize_and_exit()
+
+        custom_path_str = str(custom_answers[answer_name])
+        is_valid, error_msg = validate_relative_directory_path(custom_path_str)
+        if is_valid:
+            return Path(custom_path_str)
+
+        click.echo(f"❌ Invalid path: {error_msg}")
+        click.echo("Please enter a valid relative directory path.")
+        console.print()
+
+
+def _prompt_for_module_root(curdir: Path, project_name: str | None) -> Path:
     valid_module_subdirs, _ = get_suggestions(CommonSections.module_root)
 
     curdir_option = f"current directory ({curdir})"
@@ -191,55 +220,24 @@ def collect_setup_info() -> CLISetupInfo:
     answers = inquirer.prompt(questions, theme=CodeflashTheme())
     if not answers:
         apologize_and_exit()
+
     module_root_answer = answers["module_root"]
     if module_root_answer == curdir_option:
-        module_root = "."
-    elif module_root_answer == custom_dir_option:
-        custom_panel = Panel(
-            Text(
-                "📂 Enter a custom module directory path.\n\nPlease provide the path to your Python module directory.",
-                style="yellow",
-            ),
-            title="📂 Custom Directory",
-            border_style="bright_yellow",
+        return Path()
+    if module_root_answer == custom_dir_option:
+        return _prompt_for_custom_relative_directory(
+            panel_title="📂 Custom Directory",
+            panel_body="📂 Enter a custom module directory path.\n\nPlease provide the path to your Python module directory.",
+            answer_name="custom_path",
+            message="Enter the path to your module directory",
         )
-        console.print(custom_panel)
-        console.print()
+    return Path(cast("str", module_root_answer))
 
-        # Retry loop for custom module root path
-        custom_module_root: Path | None = None
-        while custom_module_root is None:
-            custom_questions = [
-                inquirer.Path(
-                    "custom_path",
-                    message="Enter the path to your module directory",
-                    path_type=inquirer.Path.DIRECTORY,
-                    exists=True,
-                )
-            ]
 
-            custom_answers = inquirer.prompt(custom_questions, theme=CodeflashTheme())
-            if not custom_answers:
-                apologize_and_exit()
-
-            custom_path_str = str(custom_answers["custom_path"])
-            # Validate the path is safe
-            is_valid, error_msg = validate_relative_directory_path(custom_path_str)
-            if not is_valid:
-                click.echo(f"❌ Invalid path: {error_msg}")
-                click.echo("Please enter a valid relative directory path.")
-                console.print()  # Add spacing before retry
-                continue  # Retry the prompt
-            custom_module_root = Path(custom_path_str)
-        module_root = str(custom_module_root)
-    else:
-        module_root = module_root_answer
-    ph("cli-project-root-provided")
-
-    # Discover test directory
+def _prompt_for_tests_root(curdir: Path, module_root: Path) -> Path:
     create_for_me_option = f"🆕 Create a new tests{os.pathsep} directory for me!"
     tests_suggestions, default_tests_subdir = get_suggestions(CommonSections.tests_root)
-    test_subdir_options = [sub_dir for sub_dir in tests_suggestions if sub_dir != module_root]
+    test_subdir_options = [sub_dir for sub_dir in tests_suggestions if sub_dir != str(module_root)]
     if "tests" not in tests_suggestions:
         test_subdir_options.append(create_for_me_option)
     custom_dir_option = "📁 Enter a custom directory…"
@@ -271,66 +269,34 @@ def collect_setup_info() -> CLISetupInfo:
     tests_answers = inquirer.prompt(tests_questions, theme=CodeflashTheme())
     if not tests_answers:
         apologize_and_exit()
+
     tests_root_answer = tests_answers["tests_root"]
 
     if tests_root_answer == create_for_me_option:
-        tests_root = Path(curdir) / (default_tests_subdir or "tests")
-        tests_root.mkdir()
-        click.echo(f"✅ Created directory {tests_root}{os.path.sep}{LF}")
-    elif tests_root_answer == custom_dir_option:
-        custom_tests_panel = Panel(
-            Text(
-                "🧪 Enter a custom test directory path.\n\nPlease provide the path to your test directory, relative to the current directory.",
-                style="yellow",
-            ),
-            title="🧪 Custom Test Directory",
-            border_style="bright_yellow",
+        tests_root = Path(default_tests_subdir or "tests")
+        (curdir / tests_root).mkdir()
+        click.echo(f"✅ Created directory {curdir / tests_root}{os.path.sep}{LF}")
+        return tests_root
+    if tests_root_answer == custom_dir_option:
+        return _prompt_for_custom_relative_directory(
+            panel_title="🧪 Custom Test Directory",
+            panel_body="🧪 Enter a custom test directory path.\n\nPlease provide the path to your test directory, relative to the current directory.",
+            answer_name="custom_tests_path",
+            message="Enter the path to your tests directory",
         )
-        console.print(custom_tests_panel)
-        console.print()
+    return Path(cast("str", tests_root_answer))
 
-        # Retry loop for custom tests root path
-        custom_tests_root: Path | None = None
-        while custom_tests_root is None:
-            custom_tests_questions = [
-                inquirer.Path(
-                    "custom_tests_path",
-                    message="Enter the path to your tests directory",
-                    path_type=inquirer.Path.DIRECTORY,
-                    exists=True,
-                )
-            ]
 
-            custom_tests_answers = inquirer.prompt(custom_tests_questions, theme=CodeflashTheme())
-            if not custom_tests_answers:
-                apologize_and_exit()
-
-            custom_tests_path_str = str(custom_tests_answers["custom_tests_path"])
-            # Validate the path is safe
-            is_valid, error_msg = validate_relative_directory_path(custom_tests_path_str)
-            if not is_valid:
-                click.echo(f"❌ Invalid path: {error_msg}")
-                click.echo("Please enter a valid relative directory path.")
-                console.print()  # Add spacing before retry
-                continue  # Retry the prompt
-            custom_tests_root = Path(curdir) / Path(custom_tests_path_str)
-        tests_root = custom_tests_root
-    else:
-        tests_root = Path(curdir) / Path(cast("str", tests_root_answer))
-
-    tests_root = tests_root.relative_to(curdir)
-
-    resolved_module_root = (Path(curdir) / Path(module_root)).resolve()
-    resolved_tests_root = (Path(curdir) / Path(tests_root)).resolve()
+def _warn_if_tests_root_matches_module_root(curdir: Path, module_root: Path, tests_root: Path) -> None:
+    resolved_module_root = (curdir / module_root).resolve()
+    resolved_tests_root = (curdir / tests_root).resolve()
     if resolved_module_root == resolved_tests_root:
         logger.warning(
             "It looks like your tests root is the same as your module root. This is not recommended and can lead to unexpected behavior."
         )
 
-    ph("cli-tests-root-provided")
 
-    benchmarks_root = None
-
+def _prompt_for_formatter() -> str:
     formatter_panel = Panel(
         Text(
             "🎨 Let's configure your code formatter.\n\n"
@@ -362,47 +328,67 @@ def collect_setup_info() -> CLISetupInfo:
     formatter_answers = inquirer.prompt(formatter_questions, theme=CodeflashTheme())
     if not formatter_answers:
         apologize_and_exit()
-    formatter = formatter_answers["formatter"]
+    return cast("str", formatter_answers["formatter"])
 
-    git_remote = ""
+
+def _select_git_remote(module_root: Path) -> str:
+    from git import InvalidGitRepositoryError, Repo
+
     try:
         repo = Repo(str(module_root), search_parent_directories=True)
         git_remotes = get_git_remotes(repo)
-        if git_remotes:  # Only proceed if there are remotes
-            if len(git_remotes) > 1:
-                git_panel = Panel(
-                    Text(
-                        "🔗 Configure Git Remote for Pull Requests.\n\n"
-                        "Codeflash will use this remote to create pull requests with optimized code.",
-                        style="blue",
-                    ),
-                    title="🔗 Git Remote Setup",
-                    border_style="bright_blue",
-                )
-                console.print(git_panel)
-                console.print()
-
-                git_questions = [
-                    inquirer.List(
-                        "git_remote",
-                        message="Which git remote should Codeflash use for Pull Requests?",
-                        choices=git_remotes,
-                        default="origin",
-                        carousel=True,
-                    )
-                ]
-
-                git_answers = inquirer.prompt(git_questions, theme=CodeflashTheme())
-                git_remote = git_answers["git_remote"] if git_answers else git_remotes[0]
-            else:
-                git_remote = git_remotes[0]
-        else:
+        if not git_remotes:
             click.echo(
                 "No git remotes found. You can still use Codeflash locally, but you'll need to set up a remote "
                 "repository to use GitHub features."
             )
+            return ""
+
+        if len(git_remotes) == 1:
+            return git_remotes[0]
+
+        git_panel = Panel(
+            Text(
+                "🔗 Configure Git Remote for Pull Requests.\n\n"
+                "Codeflash will use this remote to create pull requests with optimized code.",
+                style="blue",
+            ),
+            title="🔗 Git Remote Setup",
+            border_style="bright_blue",
+        )
+        console.print(git_panel)
+        console.print()
+
+        git_questions = [
+            inquirer.List(
+                "git_remote",
+                message="Which git remote should Codeflash use for Pull Requests?",
+                choices=git_remotes,
+                default="origin",
+                carousel=True,
+            )
+        ]
+
+        git_answers = inquirer.prompt(git_questions, theme=CodeflashTheme())
+        return git_answers["git_remote"] if git_answers else git_remotes[0]
     except InvalidGitRepositoryError:
-        git_remote = ""
+        return ""
+
+
+def collect_setup_info() -> CLISetupInfo:
+    curdir = Path.cwd()
+    _ensure_current_directory_is_writable(curdir)
+
+    project_name = check_for_toml_or_setup_file()
+    module_root = _prompt_for_module_root(curdir, project_name)
+    ph("cli-project-root-provided")
+
+    tests_root = _prompt_for_tests_root(curdir, module_root)
+    _warn_if_tests_root_matches_module_root(curdir, module_root, tests_root)
+    ph("cli-tests-root-provided")
+
+    formatter = _prompt_for_formatter()
+    git_remote = _select_git_remote(module_root)
 
     enable_telemetry = ask_for_telemetry()
 
@@ -410,9 +396,9 @@ def collect_setup_info() -> CLISetupInfo:
     return CLISetupInfo(
         module_root=str(module_root),
         tests_root=str(tests_root),
-        benchmarks_root=str(benchmarks_root) if benchmarks_root else None,
+        benchmarks_root=None,
         ignore_paths=ignore_paths,
-        formatter=cast("str", formatter),
+        formatter=formatter,
         git_remote=str(git_remote),
         enable_telemetry=enable_telemetry,
     )

--- a/codeflash/code_utils/instrument_existing_tests.py
+++ b/codeflash/code_utils/instrument_existing_tests.py
@@ -1032,11 +1032,28 @@ def _create_device_sync_statements(
     return sync_statements
 
 
-def create_wrapper_function(
-    mode: TestingMode = TestingMode.BEHAVIOR, used_frameworks: dict[str, str] | None = None
-) -> ast.FunctionDef:
-    lineno = 1
-    wrapper_body: list[ast.stmt] = [
+def _create_perf_counter_call() -> ast.Call:
+    return ast.Call(
+        func=ast.Attribute(value=ast.Name(id="time", ctx=ast.Load()), attr="perf_counter_ns", ctx=ast.Load()),
+        args=[],
+        keywords=[],
+    )
+
+
+def _create_codeflash_duration_assignment(lineno: int) -> ast.Assign:
+    return ast.Assign(
+        targets=[ast.Name(id="codeflash_duration", ctx=ast.Store())],
+        value=ast.BinOp(
+            left=_create_perf_counter_call(),
+            op=ast.Sub(),
+            right=ast.Name(id="counter", ctx=ast.Load()),
+        ),
+        lineno=lineno,
+    )
+
+
+def _create_wrapper_invocation_tracking_statements(lineno: int) -> list[ast.stmt]:
+    return [
         ast.Assign(
             targets=[ast.Name(id="test_id", ctx=ast.Store())],
             value=ast.JoinedStr(
@@ -1065,11 +1082,7 @@ def create_wrapper_function(
             ),
             body=[
                 ast.Assign(
-                    targets=[
-                        ast.Attribute(
-                            value=ast.Name(id="codeflash_wrap", ctx=ast.Load()), attr="index", ctx=ast.Store()
-                        )
-                    ],
+                    targets=[ast.Attribute(value=ast.Name(id="codeflash_wrap", ctx=ast.Load()), attr="index", ctx=ast.Store())],
                     value=ast.Dict(keys=[], values=[]),
                     lineno=lineno + 3,
                 )
@@ -1088,9 +1101,7 @@ def create_wrapper_function(
             body=[
                 ast.AugAssign(
                     target=ast.Subscript(
-                        value=ast.Attribute(
-                            value=ast.Name(id="codeflash_wrap", ctx=ast.Load()), attr="index", ctx=ast.Load()
-                        ),
+                        value=ast.Attribute(value=ast.Name(id="codeflash_wrap", ctx=ast.Load()), attr="index", ctx=ast.Load()),
                         slice=ast.Name(id="test_id", ctx=ast.Load()),
                         ctx=ast.Store(),
                     ),
@@ -1136,66 +1147,186 @@ def create_wrapper_function(
             ),
             lineno=lineno + 8,
         ),
-        *(
-            [
-                ast.Assign(
-                    targets=[ast.Name(id="test_stdout_tag", ctx=ast.Store())],
-                    value=ast.JoinedStr(
-                        values=[
-                            ast.FormattedValue(
-                                value=ast.Name(id="codeflash_test_module_name", ctx=ast.Load()), conversion=-1
+    ]
+
+
+def _create_wrapper_stdout_statements(lineno: int) -> list[ast.stmt]:
+    return [
+        ast.Assign(
+            targets=[ast.Name(id="test_stdout_tag", ctx=ast.Store())],
+            value=ast.JoinedStr(
+                values=[
+                    ast.FormattedValue(value=ast.Name(id="codeflash_test_module_name", ctx=ast.Load()), conversion=-1),
+                    ast.Constant(value=":"),
+                    ast.FormattedValue(
+                        value=ast.IfExp(
+                            test=ast.Name(id="codeflash_test_class_name", ctx=ast.Load()),
+                            body=ast.BinOp(
+                                left=ast.Name(id="codeflash_test_class_name", ctx=ast.Load()),
+                                op=ast.Add(),
+                                right=ast.Constant(value="."),
                             ),
-                            ast.Constant(value=":"),
-                            ast.FormattedValue(
-                                value=ast.IfExp(
-                                    test=ast.Name(id="codeflash_test_class_name", ctx=ast.Load()),
-                                    body=ast.BinOp(
-                                        left=ast.Name(id="codeflash_test_class_name", ctx=ast.Load()),
-                                        op=ast.Add(),
-                                        right=ast.Constant(value="."),
-                                    ),
-                                    orelse=ast.Constant(value=""),
-                                ),
-                                conversion=-1,
-                            ),
-                            ast.FormattedValue(value=ast.Name(id="codeflash_test_name", ctx=ast.Load()), conversion=-1),
-                            ast.Constant(value=":"),
-                            ast.FormattedValue(
-                                value=ast.Name(id="codeflash_function_name", ctx=ast.Load()), conversion=-1
-                            ),
-                            ast.Constant(value=":"),
-                            ast.FormattedValue(
-                                value=ast.Name(id="codeflash_loop_index", ctx=ast.Load()), conversion=-1
-                            ),
-                            ast.Constant(value=":"),
-                            ast.FormattedValue(value=ast.Name(id="invocation_id", ctx=ast.Load()), conversion=-1),
-                        ]
+                            orelse=ast.Constant(value=""),
+                        ),
+                        conversion=-1,
                     ),
-                    lineno=lineno + 9,
-                ),
-                ast.Expr(
-                    value=ast.Call(
-                        func=ast.Name(id="print", ctx=ast.Load()),
-                        args=[
-                            ast.JoinedStr(
-                                values=[
-                                    ast.Constant(value="!$######"),
-                                    ast.FormattedValue(
-                                        value=ast.Name(id="test_stdout_tag", ctx=ast.Load()), conversion=-1
-                                    ),
-                                    ast.Constant(value="######$!"),
-                                ]
-                            )
-                        ],
-                        keywords=[],
-                    )
-                ),
-            ]
+                    ast.FormattedValue(value=ast.Name(id="codeflash_test_name", ctx=ast.Load()), conversion=-1),
+                    ast.Constant(value=":"),
+                    ast.FormattedValue(value=ast.Name(id="codeflash_function_name", ctx=ast.Load()), conversion=-1),
+                    ast.Constant(value=":"),
+                    ast.FormattedValue(value=ast.Name(id="codeflash_loop_index", ctx=ast.Load()), conversion=-1),
+                    ast.Constant(value=":"),
+                    ast.FormattedValue(value=ast.Name(id="invocation_id", ctx=ast.Load()), conversion=-1),
+                ]
+            ),
+            lineno=lineno + 9,
         ),
+        ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id="print", ctx=ast.Load()),
+                args=[
+                    ast.JoinedStr(
+                        values=[
+                            ast.Constant(value="!$######"),
+                            ast.FormattedValue(value=ast.Name(id="test_stdout_tag", ctx=ast.Load()), conversion=-1),
+                            ast.Constant(value="######$!"),
+                        ]
+                    )
+                ],
+                keywords=[],
+            )
+        ),
+    ]
+
+
+def _create_wrapper_try_statement(lineno: int, used_frameworks: dict[str, str] | None) -> ast.Try:
+    return ast.Try(
+        body=[
+            *_create_device_sync_statements(used_frameworks, for_return_value=False),
+            ast.Assign(
+                targets=[ast.Name(id="counter", ctx=ast.Store())],
+                value=_create_perf_counter_call(),
+                lineno=lineno + 11,
+            ),
+            ast.Assign(
+                targets=[ast.Name(id="return_value", ctx=ast.Store())],
+                value=ast.Call(
+                    func=ast.Name(id="codeflash_wrapped", ctx=ast.Load()),
+                    args=[ast.Starred(value=ast.Name(id="args", ctx=ast.Load()), ctx=ast.Load())],
+                    keywords=[ast.keyword(arg=None, value=ast.Name(id="kwargs", ctx=ast.Load()))],
+                ),
+                lineno=lineno + 12,
+            ),
+            *_create_device_sync_statements(used_frameworks, for_return_value=True),
+            _create_codeflash_duration_assignment(lineno + 13),
+        ],
+        handlers=[
+            ast.ExceptHandler(
+                type=ast.Name(id="Exception", ctx=ast.Load()),
+                name="e",
+                body=[
+                    _create_codeflash_duration_assignment(lineno + 15),
+                    ast.Assign(
+                        targets=[ast.Name(id="exception", ctx=ast.Store())],
+                        value=ast.Name(id="e", ctx=ast.Load()),
+                        lineno=lineno + 13,
+                    ),
+                ],
+                lineno=lineno + 14,
+            )
+        ],
+        orelse=[],
+        finalbody=[],
+        lineno=lineno + 11,
+    )
+
+
+def _create_wrapper_behavior_statements(lineno: int) -> list[ast.stmt]:
+    return [
+        ast.Assign(
+            targets=[ast.Name(id="pickled_return_value", ctx=ast.Store())],
+            value=ast.IfExp(
+                test=ast.Name(id="exception", ctx=ast.Load()),
+                body=ast.Call(
+                    func=ast.Attribute(value=ast.Name(id="pickle", ctx=ast.Load()), attr="dumps", ctx=ast.Load()),
+                    args=[ast.Name(id="exception", ctx=ast.Load())],
+                    keywords=[],
+                ),
+                orelse=ast.Call(
+                    func=ast.Attribute(value=ast.Name(id="pickle", ctx=ast.Load()), attr="dumps", ctx=ast.Load()),
+                    args=[ast.Name(id="return_value", ctx=ast.Load())],
+                    keywords=[],
+                ),
+            ),
+            lineno=lineno + 18,
+        ),
+        ast.Expr(
+            value=ast.Call(
+                func=ast.Attribute(value=ast.Name(id="codeflash_cur", ctx=ast.Load()), attr="execute", ctx=ast.Load()),
+                args=[
+                    ast.Constant(value="INSERT INTO test_results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"),
+                    ast.Tuple(
+                        elts=[
+                            ast.Name(id="codeflash_test_module_name", ctx=ast.Load()),
+                            ast.Name(id="codeflash_test_class_name", ctx=ast.Load()),
+                            ast.Name(id="codeflash_test_name", ctx=ast.Load()),
+                            ast.Name(id="codeflash_function_name", ctx=ast.Load()),
+                            ast.Name(id="codeflash_loop_index", ctx=ast.Load()),
+                            ast.Name(id="invocation_id", ctx=ast.Load()),
+                            ast.Name(id="codeflash_duration", ctx=ast.Load()),
+                            ast.Name(id="pickled_return_value", ctx=ast.Load()),
+                            ast.Constant(value=VerificationType.FUNCTION_CALL.value),
+                        ],
+                        ctx=ast.Load(),
+                    ),
+                ],
+                keywords=[],
+            ),
+            lineno=lineno + 20,
+        ),
+        ast.Expr(
+            value=ast.Call(
+                func=ast.Attribute(value=ast.Name(id="codeflash_con", ctx=ast.Load()), attr="commit", ctx=ast.Load()),
+                args=[],
+                keywords=[],
+            ),
+            lineno=lineno + 21,
+        ),
+    ]
+
+
+def _create_wrapper_args(mode: TestingMode) -> ast.arguments:
+    return ast.arguments(
+        args=[
+            ast.arg(arg="codeflash_wrapped", annotation=None),
+            ast.arg(arg="codeflash_test_module_name", annotation=None),
+            ast.arg(arg="codeflash_test_class_name", annotation=None),
+            ast.arg(arg="codeflash_test_name", annotation=None),
+            ast.arg(arg="codeflash_function_name", annotation=None),
+            ast.arg(arg="codeflash_line_id", annotation=None),
+            ast.arg(arg="codeflash_loop_index", annotation=None),
+            *([ast.arg(arg="codeflash_cur", annotation=None)] if mode == TestingMode.BEHAVIOR else []),
+            *([ast.arg(arg="codeflash_con", annotation=None)] if mode == TestingMode.BEHAVIOR else []),
+        ],
+        vararg=ast.arg(arg="args"),
+        kwarg=ast.arg(arg="kwargs"),
+        posonlyargs=[],
+        kwonlyargs=[],
+        kw_defaults=[],
+        defaults=[],
+    )
+
+
+def create_wrapper_function(
+    mode: TestingMode = TestingMode.BEHAVIOR, used_frameworks: dict[str, str] | None = None
+) -> ast.FunctionDef:
+    lineno = 1
+    wrapper_body: list[ast.stmt] = [
+        *_create_wrapper_invocation_tracking_statements(lineno),
+        *_create_wrapper_stdout_statements(lineno),
         ast.Assign(
             targets=[ast.Name(id="exception", ctx=ast.Store())], value=ast.Constant(value=None), lineno=lineno + 10
         ),
-        # Pre-compute device sync conditions before profiling to avoid overhead during timing
         *_create_device_sync_precompute_statements(used_frameworks),
         ast.Expr(
             value=ast.Call(
@@ -1205,83 +1336,7 @@ def create_wrapper_function(
             ),
             lineno=lineno + 9,
         ),
-        ast.Try(
-            body=[
-                # Pre-sync: synchronize device before starting timer
-                *_create_device_sync_statements(used_frameworks, for_return_value=False),
-                ast.Assign(
-                    targets=[ast.Name(id="counter", ctx=ast.Store())],
-                    value=ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id="time", ctx=ast.Load()), attr="perf_counter_ns", ctx=ast.Load()
-                        ),
-                        args=[],
-                        keywords=[],
-                    ),
-                    lineno=lineno + 11,
-                ),
-                ast.Assign(
-                    targets=[ast.Name(id="return_value", ctx=ast.Store())],
-                    value=ast.Call(
-                        func=ast.Name(id="codeflash_wrapped", ctx=ast.Load()),
-                        args=[ast.Starred(value=ast.Name(id="args", ctx=ast.Load()), ctx=ast.Load())],
-                        keywords=[ast.keyword(arg=None, value=ast.Name(id="kwargs", ctx=ast.Load()))],
-                    ),
-                    lineno=lineno + 12,
-                ),
-                # Post-sync: synchronize device after function call to ensure all device work is complete
-                *_create_device_sync_statements(used_frameworks, for_return_value=True),
-                ast.Assign(
-                    targets=[ast.Name(id="codeflash_duration", ctx=ast.Store())],
-                    value=ast.BinOp(
-                        left=ast.Call(
-                            func=ast.Attribute(
-                                value=ast.Name(id="time", ctx=ast.Load()), attr="perf_counter_ns", ctx=ast.Load()
-                            ),
-                            args=[],
-                            keywords=[],
-                        ),
-                        op=ast.Sub(),
-                        right=ast.Name(id="counter", ctx=ast.Load()),
-                    ),
-                    lineno=lineno + 13,
-                ),
-            ],
-            handlers=[
-                ast.ExceptHandler(
-                    type=ast.Name(id="Exception", ctx=ast.Load()),
-                    name="e",
-                    body=[
-                        ast.Assign(
-                            targets=[ast.Name(id="codeflash_duration", ctx=ast.Store())],
-                            value=ast.BinOp(
-                                left=ast.Call(
-                                    func=ast.Attribute(
-                                        value=ast.Name(id="time", ctx=ast.Load()),
-                                        attr="perf_counter_ns",
-                                        ctx=ast.Load(),
-                                    ),
-                                    args=[],
-                                    keywords=[],
-                                ),
-                                op=ast.Sub(),
-                                right=ast.Name(id="counter", ctx=ast.Load()),
-                            ),
-                            lineno=lineno + 15,
-                        ),
-                        ast.Assign(
-                            targets=[ast.Name(id="exception", ctx=ast.Store())],
-                            value=ast.Name(id="e", ctx=ast.Load()),
-                            lineno=lineno + 13,
-                        ),
-                    ],
-                    lineno=lineno + 14,
-                )
-            ],
-            orelse=[],
-            finalbody=[],
-            lineno=lineno + 11,
-        ),
+        _create_wrapper_try_statement(lineno, used_frameworks),
         ast.Expr(
             value=ast.Call(
                 func=ast.Attribute(value=ast.Name(id="gc", ctx=ast.Load()), attr="enable", ctx=ast.Load()),
@@ -1314,75 +1369,7 @@ def create_wrapper_function(
                 keywords=[],
             )
         ),
-        *(
-            [
-                ast.Assign(
-                    targets=[ast.Name(id="pickled_return_value", ctx=ast.Store())],
-                    value=ast.IfExp(
-                        test=ast.Name(id="exception", ctx=ast.Load()),
-                        body=ast.Call(
-                            func=ast.Attribute(
-                                value=ast.Name(id="pickle", ctx=ast.Load()), attr="dumps", ctx=ast.Load()
-                            ),
-                            args=[ast.Name(id="exception", ctx=ast.Load())],
-                            keywords=[],
-                        ),
-                        orelse=ast.Call(
-                            func=ast.Attribute(
-                                value=ast.Name(id="pickle", ctx=ast.Load()), attr="dumps", ctx=ast.Load()
-                            ),
-                            args=[ast.Name(id="return_value", ctx=ast.Load())],
-                            keywords=[],
-                        ),
-                    ),
-                    lineno=lineno + 18,
-                )
-            ]
-            if mode == TestingMode.BEHAVIOR
-            else []
-        ),
-        *(
-            [
-                ast.Expr(
-                    value=ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id="codeflash_cur", ctx=ast.Load()), attr="execute", ctx=ast.Load()
-                        ),
-                        args=[
-                            ast.Constant(value="INSERT INTO test_results VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"),
-                            ast.Tuple(
-                                elts=[
-                                    ast.Name(id="codeflash_test_module_name", ctx=ast.Load()),
-                                    ast.Name(id="codeflash_test_class_name", ctx=ast.Load()),
-                                    ast.Name(id="codeflash_test_name", ctx=ast.Load()),
-                                    ast.Name(id="codeflash_function_name", ctx=ast.Load()),
-                                    ast.Name(id="codeflash_loop_index", ctx=ast.Load()),
-                                    ast.Name(id="invocation_id", ctx=ast.Load()),
-                                    ast.Name(id="codeflash_duration", ctx=ast.Load()),
-                                    ast.Name(id="pickled_return_value", ctx=ast.Load()),
-                                    ast.Constant(value=VerificationType.FUNCTION_CALL.value),
-                                ],
-                                ctx=ast.Load(),
-                            ),
-                        ],
-                        keywords=[],
-                    ),
-                    lineno=lineno + 20,
-                ),
-                ast.Expr(
-                    value=ast.Call(
-                        func=ast.Attribute(
-                            value=ast.Name(id="codeflash_con", ctx=ast.Load()), attr="commit", ctx=ast.Load()
-                        ),
-                        args=[],
-                        keywords=[],
-                    ),
-                    lineno=lineno + 21,
-                ),
-            ]
-            if mode == TestingMode.BEHAVIOR
-            else []
-        ),
+        *(_create_wrapper_behavior_statements(lineno) if mode == TestingMode.BEHAVIOR else []),
         ast.If(
             test=ast.Name(id="exception", ctx=ast.Load()),
             body=[ast.Raise(exc=ast.Name(id="exception", ctx=ast.Load()), cause=None, lineno=lineno + 22)],
@@ -1393,25 +1380,7 @@ def create_wrapper_function(
     ]
     return ast.FunctionDef(
         name="codeflash_wrap",
-        args=ast.arguments(
-            args=[
-                ast.arg(arg="codeflash_wrapped", annotation=None),
-                ast.arg(arg="codeflash_test_module_name", annotation=None),
-                ast.arg(arg="codeflash_test_class_name", annotation=None),
-                ast.arg(arg="codeflash_test_name", annotation=None),
-                ast.arg(arg="codeflash_function_name", annotation=None),
-                ast.arg(arg="codeflash_line_id", annotation=None),
-                ast.arg(arg="codeflash_loop_index", annotation=None),
-                *([ast.arg(arg="codeflash_cur", annotation=None)] if mode == TestingMode.BEHAVIOR else []),
-                *([ast.arg(arg="codeflash_con", annotation=None)] if mode == TestingMode.BEHAVIOR else []),
-            ],
-            vararg=ast.arg(arg="args"),
-            kwarg=ast.arg(arg="kwargs"),
-            posonlyargs=[],
-            kwonlyargs=[],
-            kw_defaults=[],
-            defaults=[],
-        ),
+        args=_create_wrapper_args(mode),
         body=wrapper_body,
         lineno=lineno,
         decorator_list=[],

--- a/codeflash/code_utils/instrument_existing_tests.py
+++ b/codeflash/code_utils/instrument_existing_tests.py
@@ -15,7 +15,7 @@ from codeflash.discovery.functions_to_optimize import FunctionToOptimize
 from codeflash.models.models import FunctionParent, TestingMode, VerificationType
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
     from codeflash.models.models import CodePosition
 
@@ -90,7 +90,7 @@ class InjectPerfOnly(ast.NodeTransformer):
         # it's much more efficient to visit nodes manually. We'll only descend into expressions/statements.
 
         # Helper for manual walk
-        def iter_ast_calls(node):
+        def iter_ast_calls(node: ast.AST) -> Iterator[ast.Call]:
             # Generator to yield each ast.Call in test_node, preserves node identity
             stack = [node]
             while stack:

--- a/codeflash/code_utils/instrument_existing_tests.py
+++ b/codeflash/code_utils/instrument_existing_tests.py
@@ -27,10 +27,12 @@ class FunctionCallNodeArguments:
 
 
 def get_call_arguments(call_node: ast.Call) -> FunctionCallNodeArguments:
+    """Capture the positional and keyword arguments from a call node."""
     return FunctionCallNodeArguments(call_node.args, call_node.keywords)
 
 
 def node_in_call_position(node: ast.AST, call_positions: list[CodePosition]) -> bool:
+    """Return whether an AST call node overlaps one of the recorded call positions."""
     # Profile: The most meaningful speedup here is to reduce attribute lookup and to localize call_positions if not empty.
     # Small optimizations for tight loop:
     if isinstance(node, ast.Call):
@@ -57,6 +59,7 @@ def node_in_call_position(node: ast.AST, call_positions: list[CodePosition]) -> 
 
 
 def is_argument_name(name: str, arguments_node: ast.arguments) -> bool:
+    """Check whether a name appears anywhere in a function signature's argument lists."""
     return any(
         element.arg == name
         for attribute_name in dir(arguments_node)
@@ -710,6 +713,13 @@ def inject_profiling_into_existing_test(
     tests_project_root: Path,
     mode: TestingMode = TestingMode.BEHAVIOR,
 ) -> tuple[bool, str | None]:
+    """Instrument matching calls in an existing sync test file and return the rewritten source.
+
+    This is the main entry point for Python test instrumentation. It rewrites the target test
+    module so matching function calls are wrapped with CodeFlash profiling logic, then prepends
+    the imports and helper wrapper needed for the selected testing mode.
+
+    """
     tests_project_root = tests_project_root.resolve()
     if function_to_optimize.is_async:
         return inject_async_profiling_into_existing_test(
@@ -1320,6 +1330,12 @@ def _create_wrapper_args(mode: TestingMode) -> ast.arguments:
 def create_wrapper_function(
     mode: TestingMode = TestingMode.BEHAVIOR, used_frameworks: dict[str, str] | None = None
 ) -> ast.FunctionDef:
+    """Build the `codeflash_wrap` AST function used to profile instrumented sync test calls.
+
+    The generated wrapper is responsible for invocation tracking, timing, optional framework
+    synchronization, stdout tagging, and behavior-mode result persistence.
+
+    """
     lineno = 1
     wrapper_body: list[ast.stmt] = [
         *_create_wrapper_invocation_tracking_statements(lineno),
@@ -1638,6 +1654,7 @@ ASYNC_HELPER_FILENAME = "codeflash_async_wrapper.py"
 
 
 def get_decorator_name_for_mode(mode: TestingMode) -> str:
+    """Return the async instrumentation decorator name for the requested testing mode."""
     if mode == TestingMode.BEHAVIOR:
         return "codeflash_behavior_async"
     if mode == TestingMode.CONCURRENCY:
@@ -1701,5 +1718,6 @@ def add_async_decorator_to_function(
 
 
 def create_instrumented_source_module_path(source_path: Path, temp_dir: Path) -> Path:
+    """Create the temp-file path used to hold an instrumented copy of a source module."""
     instrumented_filename = f"instrumented_{source_path.name}"
     return temp_dir / instrumented_filename

--- a/tests/test_cmd_init.py
+++ b/tests/test_cmd_init.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from codeflash.cli_cmds import cmd_init
 from codeflash.cli_cmds.init_config import (
     CLISetupInfo,
     VsCodeSetupInfo,
@@ -186,3 +187,47 @@ def test_get_valid_subdirs(temp_dir: Path) -> None:
     assert "tests" in dirs
     assert "dir1" in dirs
     assert "dir2" in dirs
+
+
+def test_prompt_for_custom_relative_directory_retries_until_valid(
+    temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (temp_dir / "src").mkdir()
+    invalid_path = str((temp_dir / "src").resolve())
+    prompt_answers = iter([{"custom_path": invalid_path}, {"custom_path": "src"}])
+
+    def fake_prompt(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return next(prompt_answers)
+
+    monkeypatch.chdir(temp_dir)
+    monkeypatch.setattr(cmd_init.inquirer, "prompt", fake_prompt)
+
+    prompt_for_custom_relative_directory = getattr(cmd_init, "_prompt_for_custom_relative_directory")
+    custom_path = prompt_for_custom_relative_directory(
+        panel_title="Custom",
+        panel_body="Choose a directory.",
+        answer_name="custom_path",
+        message="Enter the path",
+    )
+
+    assert custom_path == Path("src")
+
+
+def test_prompt_for_tests_root_creates_default_directory(temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    create_for_me_option = f"🆕 Create a new tests{os.pathsep} directory for me!"
+
+    def fake_suggestions(_section: object) -> tuple[list[str], None]:
+        return ["src"], None
+
+    def fake_prompt(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return {"tests_root": create_for_me_option}
+
+    monkeypatch.chdir(temp_dir)
+    monkeypatch.setattr(cmd_init, "get_suggestions", fake_suggestions)
+    monkeypatch.setattr(cmd_init.inquirer, "prompt", fake_prompt)
+
+    prompt_for_tests_root = getattr(cmd_init, "_prompt_for_tests_root")
+    tests_root = prompt_for_tests_root(temp_dir, Path("src"))
+
+    assert tests_root == Path("tests")
+    assert (temp_dir / "tests").is_dir()


### PR DESCRIPTION
##Summary

This PR refactors collect_setup_info in codeflash/cli_cmds/cmd_init.py into smaller, focused helpers without changing the user-facing setup flow.

##The original function handled several responsibilities in one place:

writable-directory validation
module root selection
tests root selection
custom path prompting and validation
formatter selection
git remote selection
final CLISetupInfo assembly
That made the setup flow harder to read, harder to review, and riskier to modify.

##What Changed

The logic is now split into dedicated helpers for:

checking whether the current directory is writable
prompting for a custom relative directory
selecting the module root
selecting the tests root
warning when module root and tests root resolve to the same path
selecting the formatter
selecting the git remote
collect_setup_info now acts as a thin orchestration layer that assembles the final setup data.

##Why This Is Better

This improves maintainability by:

reducing cognitive load in the setup flow
making each decision step easier to understand in isolation
localizing future changes to the relevant part of the flow
making the code easier to test without relying on one large interactive function
Tests Added

##Added focused tests for extracted helper behavior:

retrying custom directory input until a valid relative path is provided
creating the default tests directory when the “create for me” option is selected
Validation

uv run pytest -q tests/test_cmd_init.py
uv run ruff check codeflash/cli_cmds/cmd_init.py
<img width="1111" height="92" alt="image" src="https://github.com/user-attachments/assets/2b9c3745-a1e9-4b86-83a5-f2890fb7220b" />

Both passed.