### PR TITLE
Refactor: determine_best_candidate to isolate evaluation setup and candidate processing

### DIFF
--- a/codeflash/languages/function_optimizer.py
+++ b/codeflash/languages/function_optimizer.py
@@ -1314,25 +1314,13 @@ class FunctionOptimizer:
 
         return best_optimization
 
-    def determine_best_candidate(
+    def _initialize_candidate_evaluation(
         self,
         *,
-        candidates: list[OptimizedCandidate],
         code_context: CodeOptimizationContext,
         original_code_baseline: OriginalCodeBaseline,
-        original_helper_code: dict[Path, str],
-        file_path_to_helper_classes: dict[Path, set[str]],
         exp_type: str,
-        function_references: str,
-    ) -> BestOptimization | None:
-        """Determine the best optimization candidate from a list of candidates."""
-        logger.info(
-            f"Determining best optimization candidate (out of {len(candidates)}) for "
-            f"{self.function_to_optimize.qualified_name}…"
-        )
-        console.rule()
-
-        # Initialize evaluation context and async tasks
+    ) -> tuple[CandidateEvaluationContext, AiServiceClient, concurrent.futures.Future, str]:
         eval_ctx = CandidateEvaluationContext()
 
         self.future_all_refinements.clear()
@@ -1362,21 +1350,22 @@ class FunctionOptimizer:
             language_version=self.language_support.language_version,
             rerun_trace_id=self.rerun_trace_id,
         )
-
         normalized_original = self.language_support.normalize_code(code_context.read_writable_code.flat.strip())
-        processor = CandidateProcessor(
-            candidates,
-            future_line_profile_results,
-            eval_ctx,
-            self.effort,
-            code_context.read_writable_code.markdown,
-            self.future_all_refinements,
-            self.future_all_code_repair,
-            self.future_adaptive_optimizations,
-            normalize_fn=self.language_support.normalize_code,
-            normalized_original=normalized_original,
-            original_flat_code=code_context.read_writable_code.flat,
-        )
+        return eval_ctx, ai_service_client, future_line_profile_results, normalized_original
+
+    def _process_candidate_queue(
+        self,
+        *,
+        processor: CandidateProcessor,
+        code_context: CodeOptimizationContext,
+        original_code_baseline: OriginalCodeBaseline,
+        original_helper_code: dict[Path, str],
+        file_path_to_helper_classes: dict[Path, set[str]],
+        eval_ctx: CandidateEvaluationContext,
+        exp_type: str,
+        function_references: str,
+        normalized_original: str,
+    ) -> None:
         candidate_index = 0
 
         # Process candidates using queue-based approach
@@ -1409,6 +1398,57 @@ class FunctionOptimizer:
                 self.write_code_and_helpers(
                     self.function_to_optimize_source_code, original_helper_code, self.function_to_optimize.file_path
                 )
+
+    def determine_best_candidate(
+        self,
+        *,
+        candidates: list[OptimizedCandidate],
+        code_context: CodeOptimizationContext,
+        original_code_baseline: OriginalCodeBaseline,
+        original_helper_code: dict[Path, str],
+        file_path_to_helper_classes: dict[Path, set[str]],
+        exp_type: str,
+        function_references: str,
+    ) -> BestOptimization | None:
+        """Determine the best optimization candidate from a list of candidates."""
+        logger.info(
+            f"Determining best optimization candidate (out of {len(candidates)}) for "
+            f"{self.function_to_optimize.qualified_name}…"
+        )
+        console.rule()
+
+        eval_ctx, ai_service_client, future_line_profile_results, normalized_original = (
+            self._initialize_candidate_evaluation(
+                code_context=code_context,
+                original_code_baseline=original_code_baseline,
+                exp_type=exp_type,
+            )
+        )
+
+        processor = CandidateProcessor(
+            candidates,
+            future_line_profile_results,
+            eval_ctx,
+            self.effort,
+            code_context.read_writable_code.markdown,
+            self.future_all_refinements,
+            self.future_all_code_repair,
+            self.future_adaptive_optimizations,
+            normalize_fn=self.language_support.normalize_code,
+            normalized_original=normalized_original,
+            original_flat_code=code_context.read_writable_code.flat,
+        )
+        self._process_candidate_queue(
+            processor=processor,
+            code_context=code_context,
+            original_code_baseline=original_code_baseline,
+            original_helper_code=original_helper_code,
+            file_path_to_helper_classes=file_path_to_helper_classes,
+            eval_ctx=eval_ctx,
+            exp_type=exp_type,
+            function_references=function_references,
+            normalized_original=normalized_original,
+        )
 
         # Select and return the best optimization
         best_optimization = self.select_best_optimization(

--- a/tests/test_function_optimizer_determine_best_candidate.py
+++ b/tests/test_function_optimizer_determine_best_candidate.py
@@ -67,6 +67,7 @@ class FakeCandidateProcessor:
 
 
 def build_optimizer() -> tuple[FunctionOptimizer, RecordingExecutor, object, object]:
+    """Build a lightly mocked optimizer for determine_best_candidate tests."""
     optimizer = object.__new__(FunctionOptimizer)
     executor = RecordingExecutor()
     control_client = SimpleNamespace(optimize_python_code_line_profiler=MagicMock(name="control_line_profiler"))
@@ -105,6 +106,7 @@ def build_optimizer() -> tuple[FunctionOptimizer, RecordingExecutor, object, obj
 def test_determine_best_candidate_processes_candidates_and_logs_best(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify the control-path evaluation flow processes and logs candidates."""
     optimizer, executor, control_client, _ = build_optimizer()
     best_optimization = SimpleNamespace(name="best")
     optimizer.select_best_optimization.return_value = best_optimization
@@ -154,6 +156,7 @@ def test_determine_best_candidate_processes_candidates_and_logs_best(
 def test_determine_best_candidate_uses_local_client_for_experiment_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify experiment runs switch to the local client and skip final logging without a winner."""
     optimizer, executor, _, local_client = build_optimizer()
     monkeypatch.setattr(function_optimizer_module, "CandidateProcessor", FakeCandidateProcessor)
 

--- a/tests/test_function_optimizer_determine_best_candidate.py
+++ b/tests/test_function_optimizer_determine_best_candidate.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import codeflash.languages.function_optimizer as function_optimizer_module
+from codeflash.languages.function_optimizer import FunctionOptimizer
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class RecordingExecutor:
+    def __init__(self) -> None:
+        self.submissions: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    def submit(self, fn: object, *args: object, **kwargs: object) -> object:
+        self.submissions.append((fn, args, kwargs))
+        return SimpleNamespace(kind="future")
+
+
+class FakeCandidateProcessor:
+    last_init: dict[str, object] | None = None
+
+    def __init__(
+        self,
+        candidates: list[object],
+        future_line_profile_results: object,
+        eval_ctx: object,
+        effort: str,
+        original_markdown_code: str,
+        future_all_refinements: list[object],
+        future_all_code_repair: list[object],
+        future_adaptive_optimizations: list[object],
+        *,
+        normalize_fn: object,
+        normalized_original: str,
+        original_flat_code: str,
+    ) -> None:
+        type(self).last_init = {
+            "future_line_profile_results": future_line_profile_results,
+            "eval_ctx": eval_ctx,
+            "effort": effort,
+            "original_markdown_code": original_markdown_code,
+            "future_all_refinements": future_all_refinements,
+            "future_all_code_repair": future_all_code_repair,
+            "future_adaptive_optimizations": future_adaptive_optimizations,
+            "normalize_fn": normalize_fn,
+            "normalized_original": normalized_original,
+            "original_flat_code": original_flat_code,
+        }
+        self.candidate_len = len(candidates)
+        self.normalized_cache = {
+            candidate.optimization_id: f"cached-{candidate.optimization_id}" for candidate in candidates
+        }
+        self._nodes = [SimpleNamespace(candidate=candidate) for candidate in candidates]
+
+    def is_done(self) -> bool:
+        return not self._nodes
+
+    def get_next_candidate(self) -> object | None:
+        if not self._nodes:
+            return None
+        return self._nodes.pop(0)
+
+
+def build_optimizer() -> tuple[FunctionOptimizer, RecordingExecutor, object, object]:
+    optimizer = object.__new__(FunctionOptimizer)
+    executor = RecordingExecutor()
+    control_client = SimpleNamespace(optimize_python_code_line_profiler=MagicMock(name="control_line_profiler"))
+    local_client = SimpleNamespace(optimize_python_code_line_profiler=MagicMock(name="local_line_profiler"))
+
+    optimizer.future_all_refinements = [object()]
+    optimizer.future_all_code_repair = [object()]
+    optimizer.future_adaptive_optimizations = [object()]
+    optimizer.repair_counter = 5
+    optimizer.adaptive_optimization_counter = 7
+    optimizer.aiservice_client = control_client
+    optimizer.local_aiservice_client = local_client
+    optimizer.executor = executor
+    optimizer.experiment_id = "experiment-id"
+    optimizer.effort = "medium"
+    optimizer.is_numerical_code = True
+    optimizer.args = SimpleNamespace(no_jit_opts=False, rerun=None)
+    optimizer.language_support = SimpleNamespace(
+        language_version="3.12",
+        normalize_code=lambda code: f"normalized::{code}",
+    )
+    optimizer.function_to_optimize = SimpleNamespace(
+        qualified_name="pkg.fn",
+        language="python",
+        file_path=Path("target.py"),
+    )
+    optimizer.function_to_optimize_source_code = "original source"
+    optimizer.get_trace_id = MagicMock(side_effect=lambda exp_type: f"trace-{exp_type}")
+    optimizer.process_single_candidate = MagicMock()
+    optimizer.write_code_and_helpers = MagicMock()
+    optimizer.select_best_optimization = MagicMock(return_value=None)
+    optimizer.log_evaluation_results = MagicMock()
+    return optimizer, executor, control_client, local_client
+
+
+def test_determine_best_candidate_processes_candidates_and_logs_best(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer, executor, control_client, _ = build_optimizer()
+    best_optimization = SimpleNamespace(name="best")
+    optimizer.select_best_optimization.return_value = best_optimization
+    monkeypatch.setattr(function_optimizer_module, "CandidateProcessor", FakeCandidateProcessor)
+
+    code_context = SimpleNamespace(
+        read_writable_code=SimpleNamespace(markdown="markdown code", flat="flat code"),
+        read_only_context_code="dependency code",
+    )
+    original_code_baseline = SimpleNamespace(line_profile_results={"str_out": "line profile"})
+    candidates = [
+        SimpleNamespace(optimization_id="candidate-1"),
+        SimpleNamespace(optimization_id="candidate-2"),
+    ]
+    original_helper_code = {Path("helper.py"): "helper code"}
+
+    result = optimizer.determine_best_candidate(
+        candidates=candidates,
+        code_context=code_context,
+        original_code_baseline=original_code_baseline,
+        original_helper_code=original_helper_code,
+        file_path_to_helper_classes={},
+        exp_type="EXP0",
+        function_references="function references",
+    )
+
+    assert result is best_optimization
+    assert optimizer.future_all_refinements == []
+    assert optimizer.future_all_code_repair == []
+    assert optimizer.future_adaptive_optimizations == []
+    assert optimizer.repair_counter == 0
+    assert optimizer.adaptive_optimization_counter == 0
+    assert executor.submissions[0][0] is control_client.optimize_python_code_line_profiler
+    assert executor.submissions[0][2]["trace_id"] == "trace-EXP0"
+    assert executor.submissions[0][2]["source_code"] == "markdown code"
+    assert FakeCandidateProcessor.last_init is not None
+    assert FakeCandidateProcessor.last_init["normalized_original"] == "normalized::flat code"
+    assert [call.kwargs["candidate_index"] for call in optimizer.process_single_candidate.call_args_list] == [1, 2]
+    assert [
+        call.kwargs["cached_normalized_code"] for call in optimizer.process_single_candidate.call_args_list
+    ] == ["cached-candidate-1", "cached-candidate-2"]
+    assert optimizer.write_code_and_helpers.call_count == 2
+    assert optimizer.select_best_optimization.call_args.kwargs["ai_service_client"] is control_client
+    optimizer.log_evaluation_results.assert_called_once()
+
+
+def test_determine_best_candidate_uses_local_client_for_experiment_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer, executor, _, local_client = build_optimizer()
+    monkeypatch.setattr(function_optimizer_module, "CandidateProcessor", FakeCandidateProcessor)
+
+    code_context = SimpleNamespace(
+        read_writable_code=SimpleNamespace(markdown="markdown code", flat="flat code"),
+        read_only_context_code="dependency code",
+    )
+    original_code_baseline = SimpleNamespace(line_profile_results={"str_out": "line profile"})
+
+    result = optimizer.determine_best_candidate(
+        candidates=[],
+        code_context=code_context,
+        original_code_baseline=original_code_baseline,
+        original_helper_code={},
+        file_path_to_helper_classes={},
+        exp_type="EXP1",
+        function_references="function references",
+    )
+
+    assert result is None
+    assert executor.submissions[0][0] is local_client.optimize_python_code_line_profiler
+    assert optimizer.select_best_optimization.call_args.kwargs["ai_service_client"] is local_client
+    optimizer.log_evaluation_results.assert_not_called()


### PR DESCRIPTION
This PR refactors determine_best_candidate in codeflash/languages/function_optimizer.py into smaller, focused helpers without changing candidate evaluation behavior.

## The original method was responsible for multiple concerns in one place:

candidate-evaluation setup
async line-profiler task initialization
candidate queue processing
final best-candidate selection and result logging

That made the method harder to scan, harder to review, and more difficult to change safely.

## What Changed

The logic is now split into two dedicated private helpers:

_initialize_candidate_evaluation
Handles evaluation context setup, async state reset, counter reset, AI service client selection, line-profiler task submission, and original-code normalization.

_process_candidate_queue
Handles the queue-driven candidate-processing loop, including candidate indexing, process_single_candidate(...) calls, and the finally restore path that writes original code/helpers back after each iteration.

## determine_best_candidate now acts as the orchestration layer for:

logging the start of evaluation
initializing candidate evaluation
constructing CandidateProcessor
processing the queue
selecting the best optimization
logging evaluation results when a winning candidate exists

## Why This Is Better

This improves maintainability by:

reducing the responsibility surface of determine_best_candidate
making setup and queue-processing logic easier to understand in isolation
preserving the original control flow while making the method easier to review
lowering the risk of future edits to setup or candidate-loop behavior affecting unrelated parts of the method

## Behavior / Compatibility

This PR is intended to be behavior-preserving.

The refactor keeps the same high-level execution order:

initialize evaluation state
create the candidate processor
process candidates through the queue
restore original code/helpers in the loop’s finally path
select the best optimization
log evaluation results if a best candidate exists

No candidate-selection rules were intentionally changed.

## Tests Added

Added focused orchestration tests in tests/test_function_optimizer_determine_best_candidate.py covering:

the standard control-path flow using the main AI service client
the experiment-path flow using the local AI service client
candidate processing order and cached normalized-code propagation
preservation of the code-restore path during candidate processing
evaluation-result logging only when a best optimization is returned

## Validation

uv run pytest -q tests/test_function_optimizer_determine_best_candidate.py tests/test_early_dedup.py
uv run ruff check codeflash/languages/function_optimizer.py tests/test_function_optimizer_determine_best_candidate.py

## Results:

16 passed
ruff passed
<img width="1125" height="300" alt="image" src="https://github.com/user-attachments/assets/74e8b31d-9780-4a61-8790-cb8d555bf0a2" />


## Risk

Low.

This is a structural refactor with focused tests around the extracted orchestration behavior, and it preserves the original candidate-processing sequence rather than redesigning the optimization logic.

got this on uv run pytest. unrelated errors.
<img width="1120" height="232" alt="image" src="https://github.com/user-attachments/assets/59e09378-8f61-4ee0-ac31-cae56bdd7093" />
