### PR TITLE
Refactor: Java comparator result handling into focused helpers

### DIFF
--- a/codeflash/languages/java/comparator.py
+++ b/codeflash/languages/java/comparator.py
@@ -230,9 +230,9 @@ def compare_test_results(
     project_root: Path | None = None,
     project_classpath: str | None = None,
 ) -> tuple[bool, list]:
-    """Compare Java test results using the codeflash-runtime Comparator.
+    """Compare Java behavioral test outputs via the runtime Comparator CLI.
 
-    This function calls the Java Comparator CLI that:
+    The Java-side comparator is responsible for the heavy lifting:
     1. Reads serialized behavior data from both SQLite databases
     2. Deserializes using Kryo
     3. Compares results using deep equality (handles Maps, Lists, arrays, etc.)
@@ -249,7 +249,9 @@ def compare_test_results(
             classpath and any project class causes ClassNotFoundException.
 
     Returns:
-        Tuple of (all_equivalent, list of TestDiff objects).
+        A tuple of ``(all_equivalent, list of Test_Diff objects)``. When the comparator cannot run
+        or returns unusable output, the function fails closed as ``(False, [])`` so
+        callers do not accidentally accept an unverifiable candidate.
 
     """
     java_exe = _find_java_executable()
@@ -350,7 +352,8 @@ def values_equal(orig: str | None, cand: str | None) -> bool:
     """Compare two serialized values with numeric-aware equality.
 
     Handles boxing mismatches where Integer(0) and Long(0) serialize to different strings
-    (e.g., "0" vs "0.0") but represent the same numeric value.
+    (e.g., "0" vs "0.0") but represent the same numeric value. Non-numeric payloads
+    still compare as plain serialized strings.
     """
     if orig == cand:
         return True
@@ -370,14 +373,17 @@ def compare_invocations_directly(original_results: dict, candidate_results: dict
     """Compare test invocations directly from Python dictionaries.
 
     This is a fallback when the Java comparator is not available.
-    It performs basic equality comparison on serialized JSON values.
+    It performs a lightweight comparison on serialized result(JSON values) and error payloads without
+    deserializing Java objects, which keeps the fallback safe but less expressive than
+    the runtime-backed comparator.
 
     Args:
         original_results: Dict mapping call_id to result data from original code.
         candidate_results: Dict mapping call_id to result data from candidate code.
 
     Returns:
-        Tuple of (all_equivalent, list of TestDiff objects).
+        A tuple of ``(all_equivalent, list of TestDiff objects)`` derived from the serialized
+        invocation payloads.
 
     """
     # Import lazily to avoid circular imports

--- a/codeflash/languages/java/comparator.py
+++ b/codeflash/languages/java/comparator.py
@@ -131,6 +131,98 @@ def _find_java_executable() -> str | None:
     return None
 
 
+def _parse_comparator_output(result: subprocess.CompletedProcess[str]) -> dict | None:
+    """Parse JSON output from the Java comparator process."""
+    if not result.stdout or not result.stdout.strip():
+        logger.error("Java comparator returned empty output")
+        if result.stderr:
+            logger.error("stderr: %s", result.stderr)
+        return None
+
+    try:
+        comparison = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        logger.exception("Failed to parse Java comparator output: %s", e)
+        logger.exception("stdout: %s", result.stdout[:500] if result.stdout else "(empty)")
+        if result.stderr:
+            logger.exception("stderr: %s", result.stderr[:500])
+        return None
+
+    if result.stderr:
+        logger.debug("Java comparator stderr: %s", result.stderr.strip())
+    return comparison
+
+
+def _build_test_diffs(comparison: dict) -> list:
+    """Convert Java comparator diff payloads into TestDiff objects."""
+    # Import lazily to avoid circular imports
+    from codeflash.models.models import TestDiff, TestDiffScope
+
+    test_diffs: list[TestDiff] = []
+    for diff in comparison.get("diffs", []):
+        scope_str = diff.get("scope", "return_value")
+        scope = TestDiffScope.RETURN_VALUE
+        if scope_str in {"exception", "missing"}:
+            scope = TestDiffScope.DID_PASS
+
+        method_id = diff.get("methodId", "unknown")
+        call_id = diff.get("callId", 0)
+        test_src_code = f"// Method: {method_id}\n// Call ID: {call_id}"
+
+        test_diffs.append(
+            TestDiff(
+                scope=scope,
+                original_value=diff.get("originalValue"),
+                candidate_value=diff.get("candidateValue"),
+                test_src_code=test_src_code,
+                candidate_pytest_error=diff.get("candidateError"),
+                original_pass=scope_str != "exception",
+                candidate_pass=scope_str not in ("missing", "exception"),
+                original_pytest_error=diff.get("originalError"),
+            )
+        )
+
+        logger.debug(
+            "Java test diff:\n  Method: %s\n  Call ID: %s\n  Scope: %s\n  Original: %s\n  Candidate: %s",
+            method_id,
+            call_id,
+            scope_str,
+            str(diff.get("originalValue", "N/A"))[:100],
+            str(diff.get("candidateValue", "N/A"))[:100],
+        )
+    return test_diffs
+
+
+def _finalize_comparison_result(comparison: dict, test_diffs: list) -> tuple[bool, list]:
+    """Validate summary fields and log the final Java comparison decision."""
+    equivalent = comparison.get("equivalent", False)
+    actual_comparisons = comparison.get("actualComparisons", -1)
+    skipped_placeholders = comparison.get("skippedPlaceholders", 0)
+    skipped_deser_errors = comparison.get("skippedDeserializationErrors", 0)
+
+    if actual_comparisons == 0:
+        logger.warning(
+            "Java comparison: no actual comparisons performed "
+            "(total=%s, skipped_placeholders=%s, skipped_deser_errors=%s). "
+            "Treating as NOT equivalent.",
+            comparison.get("totalInvocations", 0),
+            skipped_placeholders,
+            skipped_deser_errors,
+        )
+        return False, []
+
+    logger.info(
+        "Java comparison: %s (%s invocations, %s compared, %s placeholder skips, %s deser skips, %s diffs)",
+        "equivalent" if equivalent else "DIFFERENT",
+        comparison.get("totalInvocations", 0),
+        actual_comparisons,
+        skipped_placeholders,
+        skipped_deser_errors,
+        len(test_diffs),
+    )
+    return equivalent, test_diffs
+
+
 def compare_test_results(
     original_sqlite_path: Path,
     candidate_sqlite_path: Path,
@@ -160,9 +252,6 @@ def compare_test_results(
         Tuple of (all_equivalent, list of TestDiff objects).
 
     """
-    # Import lazily to avoid circular imports
-    from codeflash.models.models import TestDiff, TestDiffScope
-
     java_exe = _find_java_executable()
     if not java_exe:
         logger.error("Java not found. Please install Java to compare test results.")
@@ -227,23 +316,8 @@ def compare_test_results(
             cwd=str(cwd),
         )
 
-        # Parse the JSON output
-        try:
-            if not result.stdout or not result.stdout.strip():
-                logger.error("Java comparator returned empty output")
-                if result.stderr:
-                    logger.error("stderr: %s", result.stderr)
-                return False, []
-
-            comparison = json.loads(result.stdout)
-
-            if result.stderr:
-                logger.debug("Java comparator stderr: %s", result.stderr.strip())
-        except json.JSONDecodeError as e:
-            logger.exception("Failed to parse Java comparator output: %s", e)
-            logger.exception("stdout: %s", result.stdout[:500] if result.stdout else "(empty)")
-            if result.stderr:
-                logger.exception("stderr: %s", result.stderr[:500])
+        comparison = _parse_comparator_output(result)
+        if comparison is None:
             return False, []
 
         # Check for errors in the JSON response
@@ -258,68 +332,8 @@ def compare_test_results(
                 logger.error("stderr: %s", result.stderr)
             return False, []
 
-        # Convert diffs to TestDiff objects
-        test_diffs: list[TestDiff] = []
-        for diff in comparison.get("diffs", []):
-            scope_str = diff.get("scope", "return_value")
-            scope = TestDiffScope.RETURN_VALUE
-            if scope_str in {"exception", "missing"}:
-                scope = TestDiffScope.DID_PASS
-
-            # Build test identifier
-            method_id = diff.get("methodId", "unknown")
-            call_id = diff.get("callId", 0)
-            test_src_code = f"// Method: {method_id}\n// Call ID: {call_id}"
-
-            test_diffs.append(
-                TestDiff(
-                    scope=scope,
-                    original_value=diff.get("originalValue"),
-                    candidate_value=diff.get("candidateValue"),
-                    test_src_code=test_src_code,
-                    candidate_pytest_error=diff.get("candidateError"),
-                    original_pass=scope_str != "exception",
-                    candidate_pass=scope_str not in ("missing", "exception"),
-                    original_pytest_error=diff.get("originalError"),
-                )
-            )
-
-            logger.debug(
-                "Java test diff:\n  Method: %s\n  Call ID: %s\n  Scope: %s\n  Original: %s\n  Candidate: %s",
-                method_id,
-                call_id,
-                scope_str,
-                str(diff.get("originalValue", "N/A"))[:100],
-                str(diff.get("candidateValue", "N/A"))[:100],
-            )
-
-        equivalent = comparison.get("equivalent", False)
-        actual_comparisons = comparison.get("actualComparisons", -1)
-        skipped_placeholders = comparison.get("skippedPlaceholders", 0)
-        skipped_deser_errors = comparison.get("skippedDeserializationErrors", 0)
-
-        if actual_comparisons == 0:
-            logger.warning(
-                "Java comparison: no actual comparisons performed "
-                "(total=%s, skipped_placeholders=%s, skipped_deser_errors=%s). "
-                "Treating as NOT equivalent.",
-                comparison.get("totalInvocations", 0),
-                skipped_placeholders,
-                skipped_deser_errors,
-            )
-            return False, []
-
-        logger.info(
-            "Java comparison: %s (%s invocations, %s compared, %s placeholder skips, %s deser skips, %s diffs)",
-            "equivalent" if equivalent else "DIFFERENT",
-            comparison.get("totalInvocations", 0),
-            actual_comparisons,
-            skipped_placeholders,
-            skipped_deser_errors,
-            len(test_diffs),
-        )
-
-        return equivalent, test_diffs
+        test_diffs = _build_test_diffs(comparison)
+        return _finalize_comparison_result(comparison, test_diffs)
 
     except subprocess.TimeoutExpired:
         logger.exception("Java comparator timed out")


### PR DESCRIPTION
This PR refactors compare_test_results in codeflash/languages/java/comparator.py to reduce local complexity without changing comparison behavior. Issue #526 

The original function handled several responsibilities in one place:

- Java/runtime and SQLite path validation
- comparator subprocess execution
- comparator JSON parsing and stderr handling
- translation of comparator diffs into TestDiff objects
- final equivalence/summary validation and logging

That made the function harder to review and harder to modify safely, especially in a path that mixes subprocess failure handling with result translation.

## What Changed

The result-handling portion of compare_test_results is now split into focused private helpers:

- _parse_comparator_output  
  Validates stdout, parses the JSON payload, and preserves the existing stderr/debug logging behavior.

- _build_test_diffs  
  Converts the Java comparator’s diff payload into TestDiff objects and keeps the per-diff debug logging in one place.

- _finalize_comparison_result  
  Applies the final summary validation (actualComparisons, skipped placeholder/deserialization counts) and centralizes the final equivalence logging.

compare_test_results now acts as the orchestration layer for:

- prerequisite validation
- Java comparator execution
- error short-circuiting
- output parsing
- diff construction
- final result selection

## Why This Is Better

This improves maintainability by:

- reducing the responsibility surface of the main comparator entry point
- separating subprocess/output concerns from domain-level diff construction
- making the comparison flow easier to scan top-to-bottom
- lowering the risk of future changes to JSON parsing or diff translation accidentally affecting subprocess/error handling

This is intended to be a behavior-preserving refactor, not a comparison-logic change.

## Behavior / Compatibility

No comparison behavior is intended to change.

In particular, this refactor preserves:

- Java executable / runtime JAR validation
- existing subprocess invocation and timeout behavior
- empty-output and malformed-JSON handling
- error handling for comparator-provided JSON errors
- exit-code validation
- TestDiff construction rules
- the actualComparisons == 0 safeguard
- existing summary/debug logging semantics

## Validation

```bash
uv run pytest -q tests/test_languages/test_java/test_comparator.py
uv run ruff check codeflash/languages/java/comparator.py
```

## Results:

- 76 passed
- ruff passed
<img width="1919" height="130" alt="image" src="https://github.com/user-attachments/assets/06d9a861-275c-4595-9e21-20c78dbef62e" />


## Risk

Low.

This is a structural refactor in a well-covered module with dedicated Java comparator tests already in place. The refactor preserves the original execution order and error handling while only extracting cohesive result-processing steps.