### PR TITLE
chore: add CODEOWNERS based on git history

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# Default fallback
+*                                       @KRRT7
+
+# Java
+/codeflash/languages/java/              @mashraf-222 @HeshamHM28 @misrasaurabh1
+
+# JavaScript / TypeScript
+/codeflash/languages/javascript/        @Saga4 @mohammedahmed18 @KRRT7
+
+# Python language support
+/codeflash/languages/python/            @KRRT7
+
+# Core pipeline
+/codeflash/optimization/                @KRRT7 @aseembits93 @misrasaurabh1
+/codeflash/verification/                @KRRT7 @misrasaurabh1
+/codeflash/benchmarking/                @KRRT7
+/codeflash/discovery/                   @KRRT7 @misrasaurabh1
+
+# CLI & setup
+/codeflash/cli_cmds/                    @KRRT7 @misrasaurabh1
+
+# LSP
+/codeflash/lsp/                         @mohammedahmed18
+
+# API
+/codeflash/api/                         @KRRT7 @aseembits93
+
+# Tracing & entry points
+/codeflash/tracing/                     @misrasaurabh1 @KRRT7
+/codeflash/main.py                      @misrasaurabh1 @KRRT7
+/codeflash/tracer.py                    @misrasaurabh1 @KRRT7
+
+# Shared utilities
+/codeflash/code_utils/                  @KRRT7 @aseembits93 @misrasaurabh1
+/codeflash/models/                      @KRRT7
+
+# CI / workflows
+/.github/                               @KRRT7


### PR DESCRIPTION
## Linked issue or discussion

Relates to #2079

## What changed

Adds `.github/CODEOWNERS` with per-directory ownership derived from full git history analysis of current org members. PRs will now automatically request reviews from the people who actually own the code being changed, instead of pinging everyone.

## Test plan

- Verify CODEOWNERS syntax is valid (GitHub will flag errors on the PR itself)
- Open a test PR touching a Java file and confirm @mashraf-222 / @HeshamHM28 / @misrasaurabh1 are requested