### PR TITLE
chore: skip linked-issue check for org members

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,17 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
           # Skip for bots (dependabot, renovate, github-actions)
           if [[ "$PR_AUTHOR" == *"[bot]"* || "$PR_AUTHOR" == "dependabot" ]]; then
             echo "Bot PR — skipping linked issue check."
+            exit 0
+          fi
+
+          # Skip for org members and collaborators
+          if [[ "$AUTHOR_ASSOCIATION" == "MEMBER" || "$AUTHOR_ASSOCIATION" == "COLLABORATOR" ]]; then
+            echo "Org member/collaborator ($PR_AUTHOR) — skipping linked issue check."
             exit 0
           fi
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,9 +44,9 @@ jobs:
             exit 0
           fi
 
-          # Skip for org members and collaborators
-          if [[ "$AUTHOR_ASSOCIATION" == "MEMBER" || "$AUTHOR_ASSOCIATION" == "COLLABORATOR" ]]; then
-            echo "Org member/collaborator ($PR_AUTHOR) — skipping linked issue check."
+          # Skip for org members
+          if [[ "$AUTHOR_ASSOCIATION" == "MEMBER" ]]; then
+            echo "Org member ($PR_AUTHOR) — skipping linked issue check."
             exit 0
           fi
 


### PR DESCRIPTION
## Linked issue or discussion

Relates to #2093 — the linked-issue CI check was enforcing on all PRs, but org members shouldn't need it.

## What changed

Uses `github.event.pull_request.author_association` to skip the linked-issue requirement for `MEMBER` and `COLLABORATOR` authors. External contributors still must reference an issue or discussion.

## Test plan

- Open a PR as an org member without a linked issue — check should pass
- The check itself will validate on this PR (KRRT7 is MEMBER, so it should skip)