### PR TITLE
chore: fix claude hooks and add LSP tool env

### DIFF
--- a/.claude/hooks/bash-guard.sh
+++ b/.claude/hooks/bash-guard.sh
@@ -24,6 +24,10 @@ case "$FIRST_CMD" in
         echo "BLOCKED: Use the Read tool instead of \`$FIRST_CMD\`. Read provides line numbers and supports images/PDFs." >&2
         exit 2
         ;;
+    awk)
+        echo "BLOCKED: Use the Grep tool or Read tool instead of \`awk\`." >&2
+        exit 2
+        ;;
     sed)
         if echo "$COMMAND" | grep -qE '(^|[[:space:]])sed[[:space:]]+-i'; then
             echo "BLOCKED: Use the Edit tool instead of \`sed -i\`. Edit tracks changes properly." >&2

--- a/.claude/hooks/post-compact.sh
+++ b/.claude/hooks/post-compact.sh
@@ -40,10 +40,8 @@ STATE="${STATE}- libcst for code transforms, ast for read-only analysis\n"
 
 [ -z "$STATE" ] && exit 0
 
-cat <<EOF
-{
-  "systemMessage": "PRESERVE the following session state through compaction:\n$(echo -e "$STATE" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')"
-}
-EOF
+EXPANDED=$(printf '%b' "$STATE")
+jq -n --arg msg "PRESERVE the following session state through compaction:
+$EXPANDED" '{"systemMessage": $msg}'
 
 exit 0

--- a/.claude/hooks/track-read.sh
+++ b/.claude/hooks/track-read.sh
@@ -6,5 +6,6 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null |
 
 [ -z "$FILE_PATH" ] && exit 0
 
-echo "$FILE_PATH" >> "$CLAUDE_PROJECT_DIR/.claude/.read-tracker"
+TRACKER="$CLAUDE_PROJECT_DIR/.claude/.read-tracker"
+grep -qxF "$FILE_PATH" "$TRACKER" 2>/dev/null || echo "$FILE_PATH" >> "$TRACKER"
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,16 +42,6 @@
             "timeout": 5
           }
         ]
-      },
-      {
-        "matcher": "Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/require-read.sh",
-            "timeout": 5
-          }
-        ]
       }
     ],
     "PostToolUse": [
@@ -92,5 +82,8 @@
     "type": "command",
     "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/status-line.sh"
   },
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "env": {
+    "ENABLE_LSP_TOOL": "1"
+  }
 }


### PR DESCRIPTION
## Summary
- **bash-guard**: add `awk` to blocked commands (was missing despite CLAUDE.md documenting it)
- **post-compact**: replace fragile `sed`-based JSON escaping with `jq -n --arg`
- **track-read**: deduplicate entries via `grep -qxF` before appending to `.read-tracker`
- **settings**: remove redundant Edit→require-read hook (Claude Code's built-in guard fires first)
- **settings**: add `ENABLE_LSP_TOOL=1` for inline LSP diagnostics

## Test plan
- [x] Hooks tested via subagent in isolated worktree (bash-guard, require-read, track-read, post-edit-lint all pass)
- [x] post-compact and status-line reviewed for correctness