### PR TITLE
fix(ci): skip e2e tests on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,6 +322,7 @@ jobs:
     if: >-
       needs.determine-changes.outputs.e2e == 'true'
       && github.event_name != 'push'
+      && github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:
@@ -425,6 +426,7 @@ jobs:
     if: >-
       needs.determine-changes.outputs.e2e_js == 'true'
       && github.event_name != 'push'
+      && github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:
@@ -508,6 +510,7 @@ jobs:
     if: >-
       needs.determine-changes.outputs.e2e_java == 'true'
       && github.event_name != 'push'
+      && github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Linked issue or discussion

Relates to #2102 — Dependabot's better-sqlite3 bump failed all JS e2e tests because secrets aren't available.

## What changed

Added `&& github.actor != 'dependabot[bot]'` to the `if` condition on all three e2e job groups (Python, JS, Java). Dependabot PRs can't access repo secrets (`CODEFLASH_API_KEY`, `POSTHOG_API_KEY`), so e2e tests always fail with missing credentials. The gate job already accepts `skipped` as passing.

## Test plan

- CI on this PR should pass (only touches workflow file, no e2e trigger)
- After merge, re-run or rebase #2102 to verify Dependabot PRs skip e2e cleanly