### PR TITLE
fix: add permissions to tessl update caller workflow

### DIFF
--- a/.github/workflows/tessl-update.yml
+++ b/.github/workflows/tessl-update.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 9 * * 1" # Weekly on Monday at 9am UTC
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   tessl:
     uses: codeflash-ai/github-workflows/.github/workflows/tessl-update.yml@main


### PR DESCRIPTION
The reusable workflow needs `contents: write` and `pull-requests: write` but callers must grant these explicitly.