### PR TITLE
fix: pass CI bot secrets to tessl update workflow

### DIFF
--- a/.github/workflows/tessl-update.yml
+++ b/.github/workflows/tessl-update.yml
@@ -14,3 +14,5 @@ jobs:
     uses: codeflash-ai/github-workflows/.github/workflows/tessl-update.yml@main
     secrets:
       TESSL_TOKEN: ${{ secrets.TESSL_TOKEN }}
+      CI_BOT_APP_ID: ${{ secrets.CI_BOT_APP_ID }}
+      CI_BOT_PRIVATE_KEY: ${{ secrets.CI_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Pass `CI_BOT_APP_ID` and `CI_BOT_PRIVATE_KEY` org secrets to the reusable tessl update workflow for PR creation.