### PR TITLE
fix: decode help-banner test subprocess output as UTF-8

### DIFF
--- a/tests/test_help_banner.py
+++ b/tests/test_help_banner.py
@@ -4,7 +4,10 @@ import sys
 
 def test_help_displays_logo() -> None:
     result = subprocess.run(
-        [sys.executable, "-c", "from codeflash.main import main; main()", "--help"], capture_output=True, text=True
+        [sys.executable, "-c", "from codeflash.main import main; main()", "--help"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "codeflash.ai" in result.stdout
@@ -12,7 +15,10 @@ def test_help_displays_logo() -> None:
 
 def test_help_short_flag_displays_logo() -> None:
     result = subprocess.run(
-        [sys.executable, "-c", "from codeflash.main import main; main()", "-h"], capture_output=True, text=True
+        [sys.executable, "-c", "from codeflash.main import main; main()", "-h"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "codeflash.ai" in result.stdout


### PR DESCRIPTION
## Problem

`tests/test_help_banner.py` has been failing on `unit-tests (windows-latest, 3.13)` since PR #2014 introduced it. CI on main is red — see https://github.com/codeflash-ai/codeflash/actions/runs/25056045918 and earlier. The failure is `TypeError: argument of type 'NoneType' is not iterable` at `assert "codeflash.ai" in result.stdout`.

## Root Cause

`print_codeflash_banner()` renders a Rich `Panel` that contains box-drawing characters (`╭`, `╮`, `│`, `╰`, etc.). The subprocess call uses `subprocess.run(..., text=True)` without an explicit `encoding=`. On Windows, `text=True` defaults to `cp1252`, which cannot decode those code points. Python's `subprocess` catches the `UnicodeDecodeError` internally and sets `result.stdout = None`, which is what surfaces as the confusing `NoneType` error at the assertion.

## Fix

Pass `encoding="utf-8"` explicitly on both `subprocess.run` calls — matches the repo's existing `code-style.md` rule that requires `encoding="utf-8"` on `open`/`read_text`/`write_text`.

## Validation

```
$ uv run pytest tests/test_help_banner.py -v
tests/test_help_banner.py::test_help_displays_logo PASSED         [ 50%]
tests/test_help_banner.py::test_help_short_flag_displays_logo PASSED [100%]
```

Tests were already passing on Linux (`ubuntu-latest` with default UTF-8 locale); the change does not regress them. This unblocks the `required checks passed` gate on PRs #1947, #1950, #1951, #1953, and every future PR touching anything in the `unit-tests` matrix.