### PR TITLE
perf: use shallow copy for args/test_cfg in worktree mode

### DIFF
--- a/codeflash/optimization/optimizer.py
+++ b/codeflash/optimization/optimizer.py
@@ -826,8 +826,8 @@ class Optimizer:
         return Success(True)  # noqa: FBT003
 
     def mirror_paths_for_worktree_mode(self, worktree_dir: Path) -> None:
-        original_args = copy.deepcopy(self.args)
-        original_test_cfg = copy.deepcopy(self.test_cfg)
+        original_args = copy.copy(self.args)
+        original_test_cfg = copy.copy(self.test_cfg)
         self.original_args_and_test_cfg = (original_args, original_test_cfg)
 
         original_git_root = git_root_dir()

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -7,7 +7,7 @@ from codeflash.cli_cmds.cli import process_pyproject_config
 from codeflash.optimization.optimizer import Optimizer
 
 
-def test_mirror_paths_for_worktree_mode(monkeypatch: pytest.MonkeyPatch):
+def test_mirror_paths_for_worktree_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     repo_root = Path(__file__).resolve().parent.parent
     project_root = repo_root / "code_to_optimize" / "code_directories" / "nested_module_root"
 
@@ -67,3 +67,103 @@ def test_mirror_paths_for_worktree_mode(monkeypatch: pytest.MonkeyPatch):
     assert optimizer.test_cfg.tests_root == worktree_dir / "tests"
     assert optimizer.test_cfg.project_root_path == worktree_dir  # same as project_root
     assert optimizer.test_cfg.tests_project_rootdir == worktree_dir  # same as test_project_root
+
+
+def test_mirror_paths_preserves_original_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    project_root = repo_root / "code_to_optimize" / "code_directories" / "nested_module_root"
+
+    monkeypatch.setattr("codeflash.optimization.optimizer.git_root_dir", lambda: project_root)
+
+    args = Namespace()
+    args.benchmark = False
+    args.benchmarks_root = None
+    args.no_pr = True
+    args.config_file = project_root / "pyproject.toml"
+    args.file = project_root / "src" / "app" / "main.py"
+    args.worktree = True
+
+    new_args = process_pyproject_config(args)
+    optimizer = Optimizer(new_args)
+
+    original_project_root = optimizer.args.project_root
+    original_module_root = optimizer.args.module_root
+    original_file = optimizer.args.file
+    original_tests_root = optimizer.args.tests_root
+    original_test_project_root = optimizer.args.test_project_root
+
+    worktree_dir = repo_root / "worktree"
+    optimizer.mirror_paths_for_worktree_mode(worktree_dir)
+
+    assert optimizer.original_args_and_test_cfg is not None
+    saved_args = optimizer.original_args_and_test_cfg[0]
+    assert saved_args.project_root == original_project_root
+    assert saved_args.module_root == original_module_root
+    assert saved_args.file == original_file
+    assert saved_args.tests_root == original_tests_root
+    assert saved_args.test_project_root == original_test_project_root
+
+
+def test_mirror_paths_preserves_original_test_cfg(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    project_root = repo_root / "code_to_optimize" / "code_directories" / "nested_module_root"
+
+    monkeypatch.setattr("codeflash.optimization.optimizer.git_root_dir", lambda: project_root)
+
+    args = Namespace()
+    args.benchmark = False
+    args.benchmarks_root = None
+    args.no_pr = True
+    args.config_file = project_root / "pyproject.toml"
+    args.file = project_root / "src" / "app" / "main.py"
+    args.worktree = True
+
+    new_args = process_pyproject_config(args)
+    optimizer = Optimizer(new_args)
+
+    original_tests_root = optimizer.test_cfg.tests_root
+    original_project_root_path = optimizer.test_cfg.project_root_path
+    original_tests_project_rootdir = optimizer.test_cfg.tests_project_rootdir
+
+    worktree_dir = repo_root / "worktree"
+    optimizer.mirror_paths_for_worktree_mode(worktree_dir)
+
+    assert optimizer.original_args_and_test_cfg is not None
+    saved_test_cfg = optimizer.original_args_and_test_cfg[1]
+    assert saved_test_cfg.tests_root == original_tests_root
+    assert saved_test_cfg.project_root_path == original_project_root_path
+    assert saved_test_cfg.tests_project_rootdir == original_tests_project_rootdir
+
+
+def test_shallow_copy_independence(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    project_root = repo_root / "code_to_optimize" / "code_directories" / "nested_module_root"
+
+    monkeypatch.setattr("codeflash.optimization.optimizer.git_root_dir", lambda: project_root)
+
+    args = Namespace()
+    args.benchmark = False
+    args.benchmarks_root = None
+    args.no_pr = True
+    args.config_file = project_root / "pyproject.toml"
+    args.file = project_root / "src" / "app" / "main.py"
+    args.worktree = True
+
+    new_args = process_pyproject_config(args)
+    optimizer = Optimizer(new_args)
+
+    worktree_dir = repo_root / "worktree"
+    optimizer.mirror_paths_for_worktree_mode(worktree_dir)
+
+    assert optimizer.original_args_and_test_cfg is not None
+    saved_args = optimizer.original_args_and_test_cfg[0]
+    saved_test_cfg = optimizer.original_args_and_test_cfg[1]
+
+    original_project_root = saved_args.project_root
+    original_tests_root = saved_test_cfg.tests_root
+
+    optimizer.args.project_root = Path("/mutated/path")
+    optimizer.test_cfg.tests_root = Path("/mutated/tests")
+
+    assert saved_args.project_root == original_project_root
+    assert saved_test_cfg.tests_root == original_tests_root


### PR DESCRIPTION
## Summary

Replace `copy.deepcopy()` with `copy.copy()` in `mirror_paths_for_worktree_mode()`.

**Part of [#2132](https://github.com/codeflash-ai/codeflash/pull/2132)** — targeted E2E pipeline performance improvements.

## Problem

`mirror_paths_for_worktree_mode()` deep-copies `args` (argparse.Namespace) and `test_cfg` (TestConfig). Deep copy recursively traverses every attribute — expensive for objects with many fields. But both objects contain only immutable types (Path, str, bool) and all fields are reassigned as new objects after copying.

## Solution

`copy.copy()` — creates a new object with shared references to the same immutable values. Safe because every field is subsequently overwritten with a new Path/str, so the original is never mutated through the copy.

## Changes

- `codeflash/optimization/optimizer.py`: `copy.deepcopy` → `copy.copy` (2 lines)
- `tests/test_worktree.py`: 3 new tests verifying copy independence

## Test plan

- [x] `uv run pytest tests/test_worktree.py -v` — all 4 tests pass
- [x] Tests verify originals are preserved after mirroring and mutation