### PR TITLE
chore: remove linked-issue and gate CI jobs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,3 @@
-## Linked issue or discussion
-
-<!-- Every PR must link to an issue or discussion — this ensures the approach has been discussed with maintainers before implementation begins, so your work fits the project's direction and doesn't need to be reworked. -->
-<!-- Replace the line below with one of: -->
-<!-- Closes #<number> -->
-<!-- Fixes #<number> -->
-<!-- Relates to #<number> -->
-<!-- Discussion: <url> -->
-
-**Required:** <!-- CI will fail if no linked issue or discussion is found. -->
-
 ## What changed
 
 <!-- Brief description of the changes. -->

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,64 +23,6 @@ concurrency:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Linked issue check — every PR must reference an issue or discussion.
-  # Skipped on push to main and workflow_dispatch.
-  # ---------------------------------------------------------------------------
-  check-linked-issue:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    steps:
-      - name: Check PR body for linked issue or discussion
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
-        run: |
-          # Skip for bots (dependabot, renovate, github-actions)
-          if [[ "$PR_AUTHOR" == *"[bot]"* || "$PR_AUTHOR" == "dependabot" ]]; then
-            echo "Bot PR — skipping linked issue check."
-            exit 0
-          fi
-
-          # Skip for org members and collaborators
-          if [[ "$AUTHOR_ASSOCIATION" == "MEMBER" || "$AUTHOR_ASSOCIATION" == "COLLABORATOR" || "$AUTHOR_ASSOCIATION" == "OWNER" ]]; then
-            echo "Org member ($PR_AUTHOR, $AUTHOR_ASSOCIATION) — skipping linked issue check."
-            exit 0
-          fi
-
-          if [ -z "$PR_BODY" ]; then
-            echo "::error::PR body is empty. Every PR must link an issue or discussion."
-            echo "Use 'Closes #<number>', 'Fixes #<number>', 'Relates to #<number>', or include a discussion URL."
-            exit 1
-          fi
-
-          # Match: #123, GH-123, org/repo#123, Closes/Fixes/Relates/Resolves #123,
-          # or a github.com URL to an issue or discussion
-          if echo "$PR_BODY" | grep -qiP '(close[sd]?|fix(e[sd])?|relate[sd]?\s+to|resolve[sd]?)\s+#\d+'; then
-            echo "Found linked issue keyword."
-            exit 0
-          fi
-          if echo "$PR_BODY" | grep -qP '#\d+'; then
-            echo "Found issue reference."
-            exit 0
-          fi
-          if echo "$PR_BODY" | grep -qiP 'github\.com/[^\s]+/(issues|discussions)/\d+'; then
-            echo "Found GitHub issue/discussion URL."
-            exit 0
-          fi
-          if echo "$PR_BODY" | grep -qiP 'CF-#?\d+'; then
-            echo "Found Linear ticket reference."
-            exit 0
-          fi
-
-          echo "::error::No linked issue or discussion found in PR body."
-          echo "Every PR must reference an issue or discussion. See CONTRIBUTING.md for details."
-          echo "Use 'Closes #<number>', 'Fixes #<number>', 'Relates to #<number>', or include a discussion URL."
-          exit 1
-
-  # ---------------------------------------------------------------------------
   # Change detection — decides which downstream jobs actually run.
   # On push/workflow_dispatch every flag is true so all jobs execute.
   # On pull_request we diff against the merge base.
@@ -512,26 +454,3 @@ jobs:
 
       - name: Run E2E test
         run: uv run python tests/scripts/${{ matrix.script }}
-
-  # ---------------------------------------------------------------------------
-  # Gate job — the ONLY required check in the GitHub ruleset.
-  # Accepts "success" and "skipped" (job skipped by change detection).
-  # Rejects "failure" and "cancelled".
-  # ---------------------------------------------------------------------------
-  required-checks-passed:
-    name: required checks passed
-    if: always()
-    needs:
-      - check-linked-issue
-      - unit-tests
-      - coverage
-      - type-check
-      - prek
-      - e2e-python
-      - e2e-js
-      - e2e-java
-    runs-on: ubuntu-latest
-    steps:
-      - uses: codeflash-ai/github-workflows/.github/actions/required-checks-gate@main
-        with:
-          needs-json: ${{ toJSON(needs) }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,6 @@ The full ruleset is in [`.claude/rules/code-style.md`](.claude/rules/code-style.
 
 ## Branches, commits, and pull requests
 
-- **Every PR must link an issue or discussion.** Use `Closes #<number>`, `Fixes #<number>`, or `Relates to #<number>` in the PR body. CI will fail if no linked issue or discussion is found. For trivial fixes (typos, formatting), open a lightweight issue first — it only takes a moment and keeps the history traceable. The goal is to have a conversation before the code — discussing the approach on an issue or discussion helps maintainers point you in the right direction early, so your implementation fits the project's needs and you don't spend time on work that gets reworked.
 - Create a feature branch off an up-to-date `main`. Never commit directly to `main`.
 - Use conventional-commit prefixes: `fix:`, `feat:`, `refactor:`, `docs:`, `test:`, `chore:`. Keep commit messages concise (1-2 sentence body max).
 - Keep commits atomic - one logical change per commit.


### PR DESCRIPTION
## What changed
- removes the check-linked-issue job from .github/workflows/ci.yaml
- removes the required checks passed gate job from the same workflow
- removes the matching linked-issue guidance from the PR template and CONTRIBUTING.md

## Test plan
- not run locally; workflow and documentation change only